### PR TITLE
Replace scaledown by detaching EC2 from ASG

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ To achieve this, it performs the following actions:
 * Suspends AWS Autoscaling actions while update is in progress
 * Drains outdated EKS outdated worker nodes one by one
 * Terminates EC2 instances of the worker nodes one by one
-* Scales down the ASG to original count
+* Detaches EC2 instances from the ASG one by one
 * Resumes AWS Autoscaling actions
 * Resumes Kubernetes Autoscaler (Optional)
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ To achieve this, it performs the following actions:
 * Drains outdated EKS outdated worker nodes one by one
 * Terminates EC2 instances of the worker nodes one by one
 * Detaches EC2 instances from the ASG one by one
+* Scales down the ASG to original count (in case of failure)
 * Resumes AWS Autoscaling actions
 * Resumes Kubernetes Autoscaler (Optional)
 

--- a/eks_rolling_update.py
+++ b/eks_rolling_update.py
@@ -122,6 +122,9 @@ def update_asgs(asgs, cluster_name):
                     logger.info(e)
                     raise RollingUpdateException("Rolling update on asg failed", asg_name)
 
+            # scaling cluster back down
+            logger.info("Scaling asg back down to original state")
+            scale_asg(asg_name, asg_new_desired_capacity, asg_old_desired_capacity, asg_old_max_size)
             # resume aws autoscaling
             modify_aws_autoscaling(asg_name, "resume")
             # remove aws tag

--- a/lib/aws.py
+++ b/lib/aws.py
@@ -285,7 +285,7 @@ def detach_instance(instance_id, asg_name):
     """
     Detach EC2 instance from ASG given an instance ID and an ASG name
     """
-    logger.info('Detaching ec2 instance {} from asg {}...'.format(instance_id,asg_name))
+    logger.info('Detaching ec2 instance {} from asg {}...'.format(instance_id, asg_name))
     try:
         response = client.detach_instances(
             InstanceIds=[instance_id],

--- a/lib/aws.py
+++ b/lib/aws.py
@@ -279,3 +279,48 @@ def count_all_cluster_instances(cluster_name):
         count += len(asg['Instances'])
     logger.info("Current asg instance count in cluster is: {}. K8s node count should match this number".format(count))
     return count
+
+
+def detach_instance(instance_id, asg_name):
+    """
+    Detach EC2 instance from ASG given an instance ID and an ASG name
+    """
+    logger.info('Detaching ec2 instance {} from asg {}...'.format(instance_id,asg_name))
+    try:
+        response = client.detach_instances(
+            InstanceIds=[instance_id],
+            AutoScalingGroupName=asg_name,
+            ShouldDecrementDesiredCapacity=True
+        )
+        if response['ResponseMetadata']['HTTPStatusCode'] == requests.codes.ok:
+            logger.info('Instance detachement from ASG succeeded.')
+        else:
+            logger.info('Instance detachement from ASG failed. Response code was {}. Exiting.'.format(response['ResponseMetadata']['HTTPStatusCode']))
+            raise Exception('Instance detachement from ASG failed. Response code was {}. Exiting.'.format(response['ResponseMetadata']['HTTPStatusCode']))
+
+    except client.exceptions.ClientError as e:
+        if 'DryRunOperation' not in str(e):
+            raise
+
+
+def instance_detached(instance_id, max_retry=app_config['GLOBAL_MAX_RETRY'], wait=app_config['GLOBAL_HEALTH_WAIT']):
+    """
+    Checks that an ec2 instance is detached from any asg given an InstanceID
+    """
+    retry_count = 1
+    while retry_count < max_retry:
+        is_instance_detached = True
+        logger.info('Checking instance {} is detached...'.format(instance_id))
+        retry_count += 1
+        response = client.describe_auto_scaling_instances(
+            InstanceIds=[instance_id], MaxRecords=1
+        )
+        if len(response['AutoScalingInstances']) != 0:
+            is_instance_detached = False
+            logger.info('Instance {} is still attached, checking again...'.format(instance_id))
+        else:
+            logger.info('Instance {} detached!'.format(instance_id))
+            is_instance_detached = True
+            break
+        time.sleep(wait)
+    return is_instance_detached


### PR DESCRIPTION
_**Disclaimer**_: 
This PR might sound (too) opiniated.  However, this did solve a real problem we had. Hope you can benefit from it ;)

**Context**:
The current scaledown method leaves no control over which nodes are to be terminated.  The control is delegated over to the ASG, where good and bad can (and DO happen).  For instance, we were left with zero node for a minute when the ASG "choose" (for lack of better explaination) to terminate all the remaining nodes right after the scaledown/resume operations.  There is a better way IMHO.

**Proposition**:
As we already know which node just got terminated (`outdated['InstanceId']`), we can detach it from the ASG right after, and scaledown the desired value by 1 automatically through the api (`ShouldDecrementDesiredCapacity=True`).  No necessity to call `scale_asg` at the end of the process, removing the risk to have all remaining nodes (or any other unexpected node) removed all at once.