### PR TITLE
Support for launch template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ venv
 .vscode
 .env
 .coverage
+.idea

--- a/eks_rolling_update.py
+++ b/eks_rolling_update.py
@@ -51,6 +51,10 @@ def update_asgs(asgs, cluster_name):
         if 'LaunchConfigurationName' in asg:
             launch_type = "LaunchConfiguration"
             asg_lc_name = asg['LaunchConfigurationName']
+        elif 'LaunchTemplate' in asg:
+            launch_type = "LaunchTemplate"
+            asg_lt_name = asg['LaunchTemplate']['LaunchTemplateName']
+            asg_lt_version = asg['LaunchTemplate']['Version']
         elif 'MixedInstancesPolicy' in asg:
             launch_type = "LaunchTemplate"
             asg_lt_name = asg['MixedInstancesPolicy']['LaunchTemplate']['LaunchTemplateSpecification'][

--- a/lib/aws.py
+++ b/lib/aws.py
@@ -292,6 +292,10 @@ def plan_asgs(asgs):
         if 'LaunchConfigurationName' in asg:
             launch_type = "LaunchConfiguration"
             asg_lc_name = asg['LaunchConfigurationName']
+        elif 'LaunchTemplate' in asg:
+            launch_type = "LaunchTemplate"
+            asg_lt_name = asg['LaunchTemplate']['LaunchTemplateName']
+            asg_lt_version = asg['LaunchTemplate']['Version']
         elif 'MixedInstancesPolicy' in asg:
             launch_type = "LaunchTemplate"
             asg_lt_name = asg['MixedInstancesPolicy']['LaunchTemplate']['LaunchTemplateSpecification'][

--- a/lib/aws.py
+++ b/lib/aws.py
@@ -251,6 +251,7 @@ def instance_outdated_launchtemplate(instance_obj, asg_lt_name, asg_lt_version):
             return True
     elif lt_version != int(asg_lt_version):
         logger.info(f"Instance id {instance_id} has a different launch configuration version to the ASG")
+        return True
 
     logger.info("Instance id {} : OK ".format(instance_id))
     return False

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -4,4 +4,3 @@ flake8~=3.7.7
 nose2~=0.9.1
 kubernetes~=10.0.1
 python-dotenv~=0.10.2
-python-box~=3.4.5

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -1,6 +1,7 @@
-moto
-python-box==3.4.0
-flake8==3.7.7
-nose2==0.9.1
-kubernetes
-python-dotenv==0.10.2
+moto~=1.3.13
+python-box~=3.4.0
+flake8~=3.7.7
+nose2~=0.9.1
+kubernetes~=10.0.1
+python-dotenv~=0.10.2
+python-box~=3.4.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-boto3==1.9.96
-kubernetes
-python-dotenv==0.10.2
+boto3~=1.9.246
+kubernetes~=10.0.1
+python-dotenv~=0.10.2

--- a/tests/fixtures/aws_response_launchtemplate.json
+++ b/tests/fixtures/aws_response_launchtemplate.json
@@ -1,0 +1,137 @@
+{
+    "AutoScalingGroups": [
+        {
+            "AutoScalingGroupName": "mock-asg",
+            "AutoScalingGroupARN": "arn:aws:autoscaling:eu-west-1:000000000000:autoScalingGroup:00000-000-0000-0000-00000000000:autoScalingGroupName/mock-asg",
+            "LaunchTemplate": {
+                "LaunchTemplateName": "mock-lt-01",
+                "Version": "2"
+            },
+            "MinSize": 3,
+            "MaxSize": 6,
+            "DesiredCapacity": 3,
+            "DefaultCooldown": 300,
+            "AvailabilityZones": [
+                "eu-west-1b",
+                "eu-west-1c",
+                "eu-west-1a"
+            ],
+            "LoadBalancerNames": [],
+            "TargetGroupARNs": [],
+            "HealthCheckType": "EC2",
+            "HealthCheckGracePeriod": 300,
+            "Instances": [
+                {
+                    "InstanceId": "i-013eae1c2874fc0d7",
+                    "AvailabilityZone": "eu-west-1b",
+                    "LifecycleState": "InService",
+                    "HealthStatus": "Healthy",
+                    "LaunchTemplate": {
+                        "LaunchTemplateName": "mock-lt-01",
+                        "Version": "2"
+                    },
+                    "ProtectedFromScaleIn": true
+                },
+                {
+                    "InstanceId": "i-014d674859bec5d03",
+                    "AvailabilityZone": "eu-west-1a",
+                    "LifecycleState": "InService",
+                    "HealthStatus": "Healthy",
+                    "LaunchTemplate": {
+                        "LaunchTemplateName": "mock-lt-00",
+                        "Version": "2"
+                    },
+                    "ProtectedFromScaleIn": true
+                },
+                {
+                    "InstanceId": "i-0195398d827ccab16",
+                    "AvailabilityZone": "eu-west-1a",
+                    "LifecycleState": "InService",
+                    "HealthStatus": "Healthy",
+                    "LaunchTemplate": {
+                        "LaunchTemplateName": "mock-lt-01",
+                        "Version": "1"
+                    },
+                    "ProtectedFromScaleIn": true
+                }
+            ],
+            "CreatedTime": "2019-03-29 11:21:02.968000+00:00",
+            "SuspendedProcesses": [
+                {
+                    "ProcessName": "AZRebalance",
+                    "SuspensionReason": "User suspended at 2019-03-29T11:21:41Z"
+                }
+            ],
+            "VPCZoneIdentifier": "subnet-00000001,subnet-00000002,subnet-00000003",
+            "EnabledMetrics": [],
+            "Tags": [
+                {
+                    "ResourceId": "mock-asg",
+                    "ResourceType": "auto-scaling-group",
+                    "Key": "Name",
+                    "Value": "mock-eks_asg",
+                    "PropagateAtLaunch": true
+                },
+                {
+                    "ResourceId": "mock-asg",
+                    "ResourceType": "auto-scaling-group",
+                    "Key": "environment",
+                    "Value": "mock",
+                    "PropagateAtLaunch": true
+                },
+                {
+                    "ResourceId": "mock-asg",
+                    "ResourceType": "auto-scaling-group",
+                    "Key": "k8s.io/cluster-autoscaler/enabled",
+                    "Value": "true",
+                    "PropagateAtLaunch": false
+                },
+                {
+                    "ResourceId": "mock-asg",
+                    "ResourceType": "auto-scaling-group",
+                    "Key": "k8s.io/cluster-autoscaler/node-template/resources/ephemeral-storage",
+                    "Value": "100Gi",
+                    "PropagateAtLaunch": false
+                },
+                {
+                    "ResourceId": "mock-asg",
+                    "ResourceType": "auto-scaling-group",
+                    "Key": "k8s.io/cluster-autoscaler/mock-eks",
+                    "Value": "",
+                    "PropagateAtLaunch": false
+                },
+                {
+                    "ResourceId": "mock-asg",
+                    "ResourceType": "auto-scaling-group",
+                    "Key": "kubernetes.io/cluster/mock-eks",
+                    "Value": "owned",
+                    "PropagateAtLaunch": true
+                },
+                {
+                    "ResourceId": "mock-asg",
+                    "ResourceType": "auto-scaling-group",
+                    "Key": "owner",
+                    "Value": "eks",
+                    "PropagateAtLaunch": true
+                }
+            ],
+            "TerminationPolicies": [
+                "Default"
+            ],
+            "NewInstancesProtectedFromScaleIn": true,
+            "ServiceLinkedRoleARN": "arn:aws:iam::000000000000:role/aws-service-role/autoscaling.amazonaws.com/AWSServiceRoleForAutoScaling"
+        }
+    ],
+    "ResponseMetadata": {
+        "RequestId": "00000000-0000-0000-0000-0000000000000000",
+        "HTTPStatusCode": 200,
+        "HTTPHeaders": {
+            "x-amzn-requestid": "00000000-0000-0000-0000-0000000000000000",
+            "content-type": "text/xml",
+            "content-length": "16707",
+            "vary": "Accept-Encoding",
+            "date": "Tue, 21 May 2019 16:57:33 GMT"
+        },
+        "RetryAttempts": 0
+    }
+}

--- a/tests/fixtures/aws_response_launchtemplate_default.json
+++ b/tests/fixtures/aws_response_launchtemplate_default.json
@@ -1,0 +1,137 @@
+{
+    "AutoScalingGroups": [
+        {
+            "AutoScalingGroupName": "mock-asg",
+            "AutoScalingGroupARN": "arn:aws:autoscaling:eu-west-1:000000000000:autoScalingGroup:00000-000-0000-0000-00000000000:autoScalingGroupName/mock-asg",
+            "LaunchTemplate": {
+                "LaunchTemplateName": "mock-lt-01",
+                "Version": "$Default"
+            },
+            "MinSize": 3,
+            "MaxSize": 6,
+            "DesiredCapacity": 3,
+            "DefaultCooldown": 300,
+            "AvailabilityZones": [
+                "eu-west-1b",
+                "eu-west-1c",
+                "eu-west-1a"
+            ],
+            "LoadBalancerNames": [],
+            "TargetGroupARNs": [],
+            "HealthCheckType": "EC2",
+            "HealthCheckGracePeriod": 300,
+            "Instances": [
+                {
+                    "InstanceId": "i-013eae1c2874fc0d7",
+                    "AvailabilityZone": "eu-west-1b",
+                    "LifecycleState": "InService",
+                    "HealthStatus": "Healthy",
+                    "LaunchTemplate": {
+                        "LaunchTemplateName": "mock-lt-01",
+                        "Version": "2"
+                    },
+                    "ProtectedFromScaleIn": true
+                },
+                {
+                    "InstanceId": "i-014d674859bec5d03",
+                    "AvailabilityZone": "eu-west-1a",
+                    "LifecycleState": "InService",
+                    "HealthStatus": "Healthy",
+                    "LaunchTemplate": {
+                        "LaunchTemplateName": "mock-lt-00",
+                        "Version": "2"
+                    },
+                    "ProtectedFromScaleIn": true
+                },
+                {
+                    "InstanceId": "i-0195398d827ccab16",
+                    "AvailabilityZone": "eu-west-1a",
+                    "LifecycleState": "InService",
+                    "HealthStatus": "Healthy",
+                    "LaunchTemplate": {
+                        "LaunchTemplateName": "mock-lt-01",
+                        "Version": "1"
+                    },
+                    "ProtectedFromScaleIn": true
+                }
+            ],
+            "CreatedTime": "2019-03-29 11:21:02.968000+00:00",
+            "SuspendedProcesses": [
+                {
+                    "ProcessName": "AZRebalance",
+                    "SuspensionReason": "User suspended at 2019-03-29T11:21:41Z"
+                }
+            ],
+            "VPCZoneIdentifier": "subnet-00000001,subnet-00000002,subnet-00000003",
+            "EnabledMetrics": [],
+            "Tags": [
+                {
+                    "ResourceId": "mock-asg",
+                    "ResourceType": "auto-scaling-group",
+                    "Key": "Name",
+                    "Value": "mock-eks_asg",
+                    "PropagateAtLaunch": true
+                },
+                {
+                    "ResourceId": "mock-asg",
+                    "ResourceType": "auto-scaling-group",
+                    "Key": "environment",
+                    "Value": "mock",
+                    "PropagateAtLaunch": true
+                },
+                {
+                    "ResourceId": "mock-asg",
+                    "ResourceType": "auto-scaling-group",
+                    "Key": "k8s.io/cluster-autoscaler/enabled",
+                    "Value": "true",
+                    "PropagateAtLaunch": false
+                },
+                {
+                    "ResourceId": "mock-asg",
+                    "ResourceType": "auto-scaling-group",
+                    "Key": "k8s.io/cluster-autoscaler/node-template/resources/ephemeral-storage",
+                    "Value": "100Gi",
+                    "PropagateAtLaunch": false
+                },
+                {
+                    "ResourceId": "mock-asg",
+                    "ResourceType": "auto-scaling-group",
+                    "Key": "k8s.io/cluster-autoscaler/mock-eks",
+                    "Value": "",
+                    "PropagateAtLaunch": false
+                },
+                {
+                    "ResourceId": "mock-asg",
+                    "ResourceType": "auto-scaling-group",
+                    "Key": "kubernetes.io/cluster/mock-eks",
+                    "Value": "owned",
+                    "PropagateAtLaunch": true
+                },
+                {
+                    "ResourceId": "mock-asg",
+                    "ResourceType": "auto-scaling-group",
+                    "Key": "owner",
+                    "Value": "eks",
+                    "PropagateAtLaunch": true
+                }
+            ],
+            "TerminationPolicies": [
+                "Default"
+            ],
+            "NewInstancesProtectedFromScaleIn": true,
+            "ServiceLinkedRoleARN": "arn:aws:iam::000000000000:role/aws-service-role/autoscaling.amazonaws.com/AWSServiceRoleForAutoScaling"
+        }
+    ],
+    "ResponseMetadata": {
+        "RequestId": "00000000-0000-0000-0000-0000000000000000",
+        "HTTPStatusCode": 200,
+        "HTTPHeaders": {
+            "x-amzn-requestid": "00000000-0000-0000-0000-0000000000000000",
+            "content-type": "text/xml",
+            "content-length": "16707",
+            "vary": "Accept-Encoding",
+            "date": "Tue, 21 May 2019 16:57:33 GMT"
+        },
+        "RetryAttempts": 0
+    }
+}

--- a/tests/fixtures/aws_response_launchtemplate_latest.json
+++ b/tests/fixtures/aws_response_launchtemplate_latest.json
@@ -1,0 +1,137 @@
+{
+    "AutoScalingGroups": [
+        {
+            "AutoScalingGroupName": "mock-asg",
+            "AutoScalingGroupARN": "arn:aws:autoscaling:eu-west-1:000000000000:autoScalingGroup:00000-000-0000-0000-00000000000:autoScalingGroupName/mock-asg",
+            "LaunchTemplate": {
+                "LaunchTemplateName": "mock-lt-01",
+                "Version": "$Default"
+            },
+            "MinSize": 3,
+            "MaxSize": 6,
+            "DesiredCapacity": 3,
+            "DefaultCooldown": 300,
+            "AvailabilityZones": [
+                "eu-west-1b",
+                "eu-west-1c",
+                "eu-west-1a"
+            ],
+            "LoadBalancerNames": [],
+            "TargetGroupARNs": [],
+            "HealthCheckType": "EC2",
+            "HealthCheckGracePeriod": 300,
+            "Instances": [
+                {
+                    "InstanceId": "i-013eae1c2874fc0d7",
+                    "AvailabilityZone": "eu-west-1b",
+                    "LifecycleState": "InService",
+                    "HealthStatus": "Healthy",
+                    "LaunchTemplate": {
+                        "LaunchTemplateName": "mock-lt-01",
+                        "Version": "2"
+                    },
+                    "ProtectedFromScaleIn": true
+                },
+                {
+                    "InstanceId": "i-014d674859bec5d03",
+                    "AvailabilityZone": "eu-west-1a",
+                    "LifecycleState": "InService",
+                    "HealthStatus": "Healthy",
+                    "LaunchTemplate": {
+                        "LaunchTemplateName": "mock-lt-00",
+                        "Version": "2"
+                    },
+                    "ProtectedFromScaleIn": true
+                },
+                {
+                    "InstanceId": "i-0195398d827ccab16",
+                    "AvailabilityZone": "eu-west-1a",
+                    "LifecycleState": "InService",
+                    "HealthStatus": "Healthy",
+                    "LaunchTemplate": {
+                        "LaunchTemplateName": "mock-lt-01",
+                        "Version": "1"
+                    },
+                    "ProtectedFromScaleIn": true
+                }
+            ],
+            "CreatedTime": "2019-03-29 11:21:02.968000+00:00",
+            "SuspendedProcesses": [
+                {
+                    "ProcessName": "AZRebalance",
+                    "SuspensionReason": "User suspended at 2019-03-29T11:21:41Z"
+                }
+            ],
+            "VPCZoneIdentifier": "subnet-00000001,subnet-00000002,subnet-00000003",
+            "EnabledMetrics": [],
+            "Tags": [
+                {
+                    "ResourceId": "mock-asg",
+                    "ResourceType": "auto-scaling-group",
+                    "Key": "Name",
+                    "Value": "mock-eks_asg",
+                    "PropagateAtLaunch": true
+                },
+                {
+                    "ResourceId": "mock-asg",
+                    "ResourceType": "auto-scaling-group",
+                    "Key": "environment",
+                    "Value": "mock",
+                    "PropagateAtLaunch": true
+                },
+                {
+                    "ResourceId": "mock-asg",
+                    "ResourceType": "auto-scaling-group",
+                    "Key": "k8s.io/cluster-autoscaler/enabled",
+                    "Value": "true",
+                    "PropagateAtLaunch": false
+                },
+                {
+                    "ResourceId": "mock-asg",
+                    "ResourceType": "auto-scaling-group",
+                    "Key": "k8s.io/cluster-autoscaler/node-template/resources/ephemeral-storage",
+                    "Value": "100Gi",
+                    "PropagateAtLaunch": false
+                },
+                {
+                    "ResourceId": "mock-asg",
+                    "ResourceType": "auto-scaling-group",
+                    "Key": "k8s.io/cluster-autoscaler/mock-eks",
+                    "Value": "",
+                    "PropagateAtLaunch": false
+                },
+                {
+                    "ResourceId": "mock-asg",
+                    "ResourceType": "auto-scaling-group",
+                    "Key": "kubernetes.io/cluster/mock-eks",
+                    "Value": "owned",
+                    "PropagateAtLaunch": true
+                },
+                {
+                    "ResourceId": "mock-asg",
+                    "ResourceType": "auto-scaling-group",
+                    "Key": "owner",
+                    "Value": "eks",
+                    "PropagateAtLaunch": true
+                }
+            ],
+            "TerminationPolicies": [
+                "Default"
+            ],
+            "NewInstancesProtectedFromScaleIn": true,
+            "ServiceLinkedRoleARN": "arn:aws:iam::000000000000:role/aws-service-role/autoscaling.amazonaws.com/AWSServiceRoleForAutoScaling"
+        }
+    ],
+    "ResponseMetadata": {
+        "RequestId": "00000000-0000-0000-0000-0000000000000000",
+        "HTTPStatusCode": 200,
+        "HTTPHeaders": {
+            "x-amzn-requestid": "00000000-0000-0000-0000-0000000000000000",
+            "content-type": "text/xml",
+            "content-length": "16707",
+            "vary": "Accept-Encoding",
+            "date": "Tue, 21 May 2019 16:57:33 GMT"
+        },
+        "RetryAttempts": 0
+    }
+}

--- a/tests/fixtures/get_launch_template.json
+++ b/tests/fixtures/get_launch_template.json
@@ -1,0 +1,14 @@
+{
+  "LaunchTemplateId": "string",
+  "LaunchTemplateName": "mock-lt-01",
+  "CreateTime": "2019-03-29 11:21:02.968000+00:00",
+  "CreatedBy": "string",
+  "DefaultVersionNumber": 1,
+  "LatestVersionNumber": 2,
+  "Tags": [
+    {
+      "Key": "string",
+      "Value": "string"
+    }
+  ]
+}

--- a/tests/test_aws.py
+++ b/tests/test_aws.py
@@ -1,9 +1,9 @@
-
+import os
 import unittest
 import boto3
 import json
 from moto import mock_autoscaling, mock_ec2
-from lib.aws import get_asg_tag, get_asgs, instance_outdated, count_all_cluster_instances, is_asg_healthy, is_asg_scaled, modify_aws_autoscaling, save_asg_tags, delete_asg_tags, instance_terminated
+from lib.aws import get_asg_tag, get_asgs, instance_outdated_launchconfiguration, count_all_cluster_instances, is_asg_healthy, is_asg_scaled, modify_aws_autoscaling, save_asg_tags, delete_asg_tags, instance_terminated
 from unittest.mock import Mock, patch
 from mock import mock
 
@@ -46,11 +46,11 @@ class TestAWS(unittest.TestCase):
         )
         response = client.describe_auto_scaling_groups(AutoScalingGroupNames=['mock-asg'])
         self.instance_id = response['AutoScalingGroups'][0]['Instances'][0]['InstanceId']
-
-        with open("tests/fixtures/aws_response_unhealthy.json", "r") as file:
+        current_dir = os.path.dirname(os.path.abspath(__file__))
+        with open(f"{current_dir}/fixtures/aws_response_unhealthy.json", "r") as file:
             self.aws_response_mock_unhealthy = json.load(file)
 
-        with open("tests/fixtures/aws_response_terminated.json", "r") as file:
+        with open(f"{current_dir}/fixtures/aws_response_terminated.json", "r") as file:
             self.aws_response_mock_terminated = json.load(file)
 
     def test_get_asg_tag(self):
@@ -87,14 +87,14 @@ class TestAWS(unittest.TestCase):
         asgs = response['AutoScalingGroups']
         for asg in asgs:
             instances = asg['Instances']
-        self.assertFalse(instance_outdated(instances[0], 'mock-lc-01'))
+        self.assertFalse(instance_outdated_launchconfiguration(instances[0], 'mock-lc-01'))
 
     def test_is_instance_outdated_fail(self):
         response = self.aws_response_mock_unhealthy
         asgs = response['AutoScalingGroups']
         for asg in asgs:
             instances = asg['Instances']
-        self.assertTrue(instance_outdated(instances[0], 'mock-lc-01'))
+        self.assertTrue(instance_outdated_launchconfiguration(instances[0], 'mock-lc-01'))
 
     def test_count_all_cluster_instances(self):
         count = count_all_cluster_instances('mock-cluster')

--- a/tests/test_aws_launchtemplate.py
+++ b/tests/test_aws_launchtemplate.py
@@ -1,0 +1,79 @@
+import os
+import unittest
+import json
+from moto import mock_autoscaling, mock_ec2
+from lib.aws import instance_outdated_launchtemplate
+from unittest.mock import patch
+
+
+@mock_autoscaling
+@mock_ec2
+class TestAWS(unittest.TestCase):
+
+    def setUp(self):
+        current_dir = os.path.dirname(os.path.abspath(__file__))
+        with open(f"{current_dir}/fixtures/aws_response_launchtemplate.json", "r") as file:
+            self.aws_response_mock = json.load(file)
+        with open(f"{current_dir}/fixtures/aws_response_launchtemplate_default.json", "r") as file:
+            self.aws_response_mock_default = json.load(file)
+        with open(f"{current_dir}/fixtures/aws_response_launchtemplate_latest.json", "r") as file:
+            self.aws_response_mock_latest = json.load(file)
+        with open(f"{current_dir}/fixtures/get_launch_template.json", "r") as file:
+            self.mock_get_launch_template = json.load(file)
+
+    def test_is_instance_outdated(self):
+        response = self.aws_response_mock
+        asgs = response['AutoScalingGroups']
+        for asg in asgs:
+            instances = asg['Instances']
+        self.assertFalse(instance_outdated_launchtemplate(instances[0], 'mock-lt-01', '2'))
+
+    def test_is_instance_outdated_fail_name(self):
+        response = self.aws_response_mock
+        asgs = response['AutoScalingGroups']
+        for asg in asgs:
+            instances = asg['Instances']
+        self.assertTrue(instance_outdated_launchtemplate(instances[1], 'mock-lt-01', '2'))
+
+    def test_is_instance_outdated_fail_version_number(self):
+        response = self.aws_response_mock
+        asgs = response['AutoScalingGroups']
+        for asg in asgs:
+            instances = asg['Instances']
+        self.assertTrue(instance_outdated_launchtemplate(instances[2], 'mock-lt-01', '2'))
+
+    def test_is_instance_outdated_fail_version_default(self):
+        response = self.aws_response_mock_default
+        asgs = response['AutoScalingGroups']
+        for asg in asgs:
+            instances = asg['Instances']
+        with patch('lib.aws.get_launch_template') as get_launch_template_mock:
+            get_launch_template_mock.return_value = self.mock_get_launch_template
+            self.assertTrue(instance_outdated_launchtemplate(instances[0], 'mock-lt-01', '$Default'))
+
+    def test_is_instance_outdated_pass_version_default(self):
+        response = self.aws_response_mock_default
+        asgs = response['AutoScalingGroups']
+        for asg in asgs:
+            instances = asg['Instances']
+        with patch('lib.aws.get_launch_template') as get_launch_template_mock:
+            get_launch_template_mock.return_value = self.mock_get_launch_template
+            self.assertFalse(instance_outdated_launchtemplate(instances[2], 'mock-lt-01', '$Default'))
+
+    def test_is_instance_outdated_pass_version_latest(self):
+        response = self.aws_response_mock_latest
+        asgs = response['AutoScalingGroups']
+        for asg in asgs:
+            instances = asg['Instances']
+        with patch('lib.aws.get_launch_template') as get_launch_template_mock:
+            get_launch_template_mock.return_value = self.mock_get_launch_template
+            self.assertFalse(instance_outdated_launchtemplate(instances[0], 'mock-lt-01', '$Latest'))
+
+    def test_is_instance_outdated_fail_version_latest(self):
+        response = self.aws_response_mock_latest
+        asgs = response['AutoScalingGroups']
+        for asg in asgs:
+            instances = asg['Instances']
+        with patch('lib.aws.get_launch_template') as get_launch_template_mock:
+            get_launch_template_mock.return_value = self.mock_get_launch_template
+            self.assertTrue(instance_outdated_launchtemplate(instances[2], 'mock-lt-01', '$Latest'))

--- a/tests/test_k8s.py
+++ b/tests/test_k8s.py
@@ -1,4 +1,4 @@
-
+import os
 import unittest
 import json
 from moto import mock_autoscaling
@@ -11,11 +11,12 @@ from box import Box
 class TestK8S(unittest.TestCase):
 
     def setUp(self):
+        current_dir = os.path.dirname(os.path.abspath(__file__))
 
-        with open("tests/fixtures/k8s_response.json", "r") as file:
+        with open(f"{current_dir}/fixtures/k8s_response.json", "r") as file:
             self.k8s_response_mock = json.load(file)
 
-        with open("tests/fixtures/k8s_response_unhealthy.json", "r") as file:
+        with open(f"{current_dir}/fixtures/k8s_response_unhealthy.json", "r") as file:
             self.k8s_response_mock_unhealthy = json.load(file)
 
     def test_k8s_node_count(self):


### PR DESCRIPTION
This adds support for Launch Templates with and without a Mixed Instances Policy.

Confirmed working with one of my `MixedInstancesPolicy` clusters. I still need to write tests, but I thought I'd create the PR early for feedback.

Fixes #10 