### PR TITLE
enable/disable CA and some environment vars handling fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,9 +91,9 @@ eks-rolling-update.py -c my-eks-cluster
 
 | Parameter                 | Description                                                                                                        | Default                              |
 |---------------------------|--------------------------------------------------------------------------------------------------------------------|--------------------------------------|
-| K8S_AUTOSCALER_ENABLED    | If True Kubernetes Autoscaler will be paused before running update                                                 | True                                 |
-| K8S_AUTOSCALER_NAMESPACE  | Namespace where Kubernetes Autoscaler is deployed                                                                  | ""                                   |
-| K8S_AUTOSCALER_DEPLOYMENT | Deployment name of Kubernetes Autoscaler                                                                           | ""                                   |
+| K8S_AUTOSCALER_ENABLED    | If True Kubernetes Autoscaler will be paused before running update                                                 | False                                 |
+| K8S_AUTOSCALER_NAMESPACE  | Namespace where Kubernetes Autoscaler is deployed                                                                  | "default"                                   |
+| K8S_AUTOSCALER_DEPLOYMENT | Deployment name of Kubernetes Autoscaler                                                                           | "cluster-autoscaler"                                   |
 | ASG_DESIRED_STATE_TAG     | Temporary tag which will be saved to the ASG to store the state of the EKS cluster prior to update                 | eks-rolling-update:desired_capacity  |
 | ASG_ORIG_CAPACITY_TAG     | Temporary tag which will be saved to the ASG to store the state of the EKS cluster prior to update                 | eks-rolling-update:original_capacity |
 | CLUSTER_HEALTH_WAIT       | Number of seconds to wait after ASG has been scaled up before checking health of the cluster                       | 90                                   |
@@ -101,6 +101,51 @@ eks-rolling-update.py -c my-eks-cluster
 | GLOBAL_HEALTH_WAIT        | Number of seconds to wait before retrying a health check                                                           | 20                                   |
 | DRY_RUN                   | If True, only a query will be run to determine which worker nodes are outdated without running an update operation | False                                |
 
+## Examples
+  - enable the updater to operate on `cluster-autoscaler`
+    ```
+    #
+    # set your AWS environment before running eks rolling update
+    #
+
+    # NOTE: This examople will only work if you have cluster-autoscaler operating inside your cluster!
+    # Let the updater know that cluster-autoscaler is running in your cluster
+
+    $ export  K8S_AUTOSCALER_ENABLED=1 \
+              K8S_AUTOSCALER_NAMESPACE="CA_NAMESPACE" \
+              K8S_AUTOSCALER_DEPLOYMENT="CA_DEPLOYMENT_NAME"
+
+    # plan
+    $ python eks_rolling_update.py --cluster_name YOUR_EKS_CLUSTER_NAME --plan
+    ...
+
+    # apply changes
+    $ python eks_rolling_update.py --cluster_name YOUR_EKS_CLUSTER_NAME
+    ```
+- disable operations on `cluster-autoscaler`
+  ```
+    $ unset K8S_AUTOSCALER_ENABLED
+  ```
+- enable features only for one run
+  ```
+    # DRY_RUN will only be used by the current updater session
+    $ DRY_RUN=1 python eks_rolling_update.py --cluster_name YOUR_CLUSTER_NAME
+
+    # operate on cluster-autoscaler only for this updater session
+    $ K8S_AUTOSCALER_ENABLED=1 \
+      K8S_AUTOSCALER_NAMESPACE="somenamespace" \
+      K8S_AUTOSCALER_DEPLOYMENT="deploymentname" \
+      python eks_rolling_update.py --cluster_name YOUR_CLUSTER_NAME
+  ```
+- `.env` file
+  ```
+  # you can use .env file within your project directory to load updater settings
+  # e.g:
+  
+  $ cat .env
+  DRY_RUN=1
+  $
+  ```
 <a name="contributing"></a>
 ## Contributing
 

--- a/config.py
+++ b/config.py
@@ -3,9 +3,9 @@ import os
 load_dotenv()
 
 app_config = {
-    'K8S_AUTOSCALER_ENABLED': os.getenv('K8S_AUTOSCALER_ENABLED', True),
-    'K8S_AUTOSCALER_NAMESPACE': os.getenv('K8S_AUTOSCALER_NAMESPACE'),
-    'K8S_AUTOSCALER_DEPLOYMENT': os.getenv('K8S_AUTOSCALER_DEPLOYMENT'),
+    'K8S_AUTOSCALER_ENABLED': os.getenv('K8S_AUTOSCALER_ENABLED', False),
+    'K8S_AUTOSCALER_NAMESPACE': os.getenv('K8S_AUTOSCALER_NAMESPACE','default'),
+    'K8S_AUTOSCALER_DEPLOYMENT': os.getenv('K8S_AUTOSCALER_DEPLOYMENT','cluster-autoscaler'),
     'ASG_DESIRED_STATE_TAG': 'eks-rolling-update:desired_capacity',
     'ASG_ORIG_CAPACITY_TAG': 'eks-rolling-update:original_capacity',
     'CLUSTER_HEALTH_WAIT': os.getenv('CLUSTER_HEALTH_WAIT', 90),

--- a/eks_rolling_update.py
+++ b/eks_rolling_update.py
@@ -177,18 +177,19 @@ if __name__ == "__main__":
         plan_asgs(filtered_asgs)
     else:
         # perform real update
-        if app_config['K8S_AUTOSCALER_ENABLED'] is True:
+        if app_config['K8S_AUTOSCALER_ENABLED']:
             # pause k8s autoscaler
             modify_k8s_autoscaler("pause")
         try:
             update_asgs(filtered_asgs, args.cluster_name)
-            # resume autoscaler after asg updated
-            modify_k8s_autoscaler("resume")
+            if app_config['K8S_AUTOSCALER_ENABLED']:
+              # resume autoscaler after asg updated
+              modify_k8s_autoscaler("resume")
             logger.info('*** Rolling update of all asg is complete! ***')
         except RollingUpdateException as e:
             logger.info("Rolling update encountered an exception. Resuming aws autoscaling.")
             modify_aws_autoscaling(e.asg_name, "resume")
-            if app_config['K8S_AUTOSCALER_ENABLED'] is True:
+            if app_config['K8S_AUTOSCALER_ENABLED']:
                 # resume autoscaler no matter what happens
                 modify_k8s_autoscaler("resume")
             # Send exit code 1 to the caller so CI shows a failure
@@ -196,7 +197,7 @@ if __name__ == "__main__":
         except Exception as e:
             logger.info(e)
             logger.info('*** Rolling update of asg has failed. Exiting ***')
-            if app_config['K8S_AUTOSCALER_ENABLED'] is True:
+            if app_config['K8S_AUTOSCALER_ENABLED']:
                 # resume autoscaler no matter what happens
                 modify_k8s_autoscaler("resume")
             sys.exit(1)

--- a/eks_rolling_update.py
+++ b/eks_rolling_update.py
@@ -183,8 +183,8 @@ if __name__ == "__main__":
         try:
             update_asgs(filtered_asgs, args.cluster_name)
             if app_config['K8S_AUTOSCALER_ENABLED']:
-              # resume autoscaler after asg updated
-              modify_k8s_autoscaler("resume")
+                # resume autoscaler after asg updated
+                modify_k8s_autoscaler("resume")
             logger.info('*** Rolling update of all asg is complete! ***')
         except RollingUpdateException as e:
             logger.info("Rolling update encountered an exception. Resuming aws autoscaling.")

--- a/lib/aws.py
+++ b/lib/aws.py
@@ -116,7 +116,7 @@ def modify_aws_autoscaling(asg_name, action):
         asg_name,
         action)
     )
-    if app_config['DRY_RUN'] is not True:
+    if not app_config['DRY_RUN']:
 
         if action == "suspend":
             response = client.suspend_processes(
@@ -145,7 +145,7 @@ def scale_asg(asg_name, current_desired_capacity, new_desired_capacity, new_max_
     Changes the desired capacity of an asg
     """
     logger.info('Setting asg desired capacity from {} to {} and max size to {}...'.format(current_desired_capacity, new_desired_capacity, new_max_size))
-    if app_config['DRY_RUN'] is not True:
+    if not app_config['DRY_RUN']:
         response = client.update_auto_scaling_group(
             AutoScalingGroupName=asg_name,
             DesiredCapacity=new_desired_capacity,
@@ -163,7 +163,7 @@ def save_asg_tags(asg_name, key, value):
     Adds a tag to asg for later retrieval
     """
     logger.info('Saving tag to asg key: {}, value : {}...'.format(key, value))
-    if app_config['DRY_RUN'] is not True:
+    if not app_config['DRY_RUN']:
         response = client.create_or_update_tags(
             Tags=[
                 {
@@ -189,7 +189,7 @@ def delete_asg_tags(asg_name, key):
     Deletes a tag from asg
     """
     logger.info('Deleting tag from asg key: {}...'.format(key))
-    if app_config['DRY_RUN'] is not True:
+    if not app_config['DRY_RUN']:
         response = client.delete_tags(
             Tags=[
                 {


### PR DESCRIPTION
### Environment
- MacOS
- virtualenv with python 3.7.4
### Initial actions
- wanted to use `eks-rolling-update` project against an EKS cluster just for testing the rolling out of new nodes
- `cluster-autoscaler` was not deployed
### Result
- got errors when the updater tried to operate on `cluster-autoscaler`
- no way to disable it because of the way environment variables were handled
  ```
  #
  # this won't work with the current code
  #
  $ export K8S_AUTOSCALER_ENABLED=false
  $ python
  Python 3.7.4 (default, Oct 12 2019, 18:55:28)
  [Clang 11.0.0 (clang-1100.0.33.8)] on darwin
  Type "help", "copyright", "credits" or "license" for more information.
  >>> import os
  >>> v = os.getenv('K8S_AUTOSCALER_ENABLED', True)
  >>> v
  'false'
  >>> v is True
  False
  >>> v is False
  False
  ```
### Proposed changes
  - k8s autoscaler operations are disabled by default
  - added defaults for CA namespace and deployment name
  - comply with PEP8 when evaluating `booleans`
  - resume k8s autoscaler only when K8S_AUTOSCALER_ENABLED
 - added some examples
