### PR TITLE
Add ability to add additional arguments to the kubectl drain function

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,20 +90,21 @@ eks-rolling-update.py -c my-eks-cluster
 
 ## Configuration
 
-| Parameter                 | Description                                                                                                        | Default                              |
-|---------------------------|--------------------------------------------------------------------------------------------------------------------|--------------------------------------|
-| K8S_AUTOSCALER_ENABLED    | If True Kubernetes Autoscaler will be paused before running update                                                 | False                                 |
-| K8S_AUTOSCALER_NAMESPACE  | Namespace where Kubernetes Autoscaler is deployed                                                                  | "default"                                   |
-| K8S_AUTOSCALER_DEPLOYMENT | Deployment name of Kubernetes Autoscaler                                                                           | "cluster-autoscaler"                                   |
-| ASG_DESIRED_STATE_TAG     | Temporary tag which will be saved to the ASG to store the state of the EKS cluster prior to update                 | eks-rolling-update:desired_capacity  |
-| ASG_ORIG_CAPACITY_TAG     | Temporary tag which will be saved to the ASG to store the state of the EKS cluster prior to update                 | eks-rolling-update:original_capacity |
-| ASG_ORIG_MAX_CAPACITY_TAG | Temporary tag which will be saved to the ASG to store the state of the EKS cluster prior to update                 | eks-rolling-update:original_max_capacity |
-| CLUSTER_HEALTH_WAIT       | Number of seconds to wait after ASG has been scaled up before checking health of the cluster                       | 90                                   |
-| GLOBAL_MAX_RETRY          | Number of attempts of a health check                                                                               | 12                                   |
-| GLOBAL_HEALTH_WAIT        | Number of seconds to wait before retrying a health check                                                           | 20                                   |
-| BETWEEN_NODES_WAIT        | Number of seconds to wait after removing a node before continuing on                                               | 0                                    |
-| RUN_MODE                  | See Run Modes section below                                                                                        | 1                                    |
-| DRY_RUN                   | If True, only a query will be run to determine which worker nodes are outdated without running an update operation | False                                |
+| Parameter                 | Description                                                                                                           | Default                                  |
+|---------------------------|-----------------------------------------------------------------------------------------------------------------------|------------------------------------------|
+| K8S_AUTOSCALER_ENABLED    | If True Kubernetes Autoscaler will be paused before running update                                                    | False                                    |
+| K8S_AUTOSCALER_NAMESPACE  | Namespace where Kubernetes Autoscaler is deployed                                                                     | "default"                                |
+| K8S_AUTOSCALER_DEPLOYMENT | Deployment name of Kubernetes Autoscaler                                                                              | "cluster-autoscaler"                     |
+| ASG_DESIRED_STATE_TAG     | Temporary tag which will be saved to the ASG to store the state of the EKS cluster prior to update                    | eks-rolling-update:desired_capacity      |
+| ASG_ORIG_CAPACITY_TAG     | Temporary tag which will be saved to the ASG to store the state of the EKS cluster prior to update                    | eks-rolling-update:original_capacity     |
+| ASG_ORIG_MAX_CAPACITY_TAG | Temporary tag which will be saved to the ASG to store the state of the EKS cluster prior to update                    | eks-rolling-update:original_max_capacity |
+| CLUSTER_HEALTH_WAIT       | Number of seconds to wait after ASG has been scaled up before checking health of the cluster                          | 90                                       |
+| GLOBAL_MAX_RETRY          | Number of attempts of a health check                                                                                  | 12                                       |
+| GLOBAL_HEALTH_WAIT        | Number of seconds to wait before retrying a health check                                                              | 20                                       |
+| BETWEEN_NODES_WAIT        | Number of seconds to wait after removing a node before continuing on                                                  | 0                                        |
+| RUN_MODE                  | See Run Modes section below                                                                                           | 1                                        |
+| DRY_RUN                   | If True, only a query will be run to determine which worker nodes are outdated without running an update operation    | False                                    |
+| EXTRA_DRAIN_ARGS          | Additional space-delimited args to supply to the `kubectl drain` function, e.g `--force=true`. See `kubectl drain -h` | ""                                       |
 
 ## Run Modes
 There are a number of different values which can be set for the `RUN_MODE` environment variable. 

--- a/config.py
+++ b/config.py
@@ -1,9 +1,13 @@
 from dotenv import load_dotenv
+from distutils.util import strtobool
 import os
 load_dotenv()
 
+def str_to_bool(val):
+    return val if type(val) is bool else bool(strtobool(val))
+
 app_config = {
-    'K8S_AUTOSCALER_ENABLED': bool(os.getenv('K8S_AUTOSCALER_ENABLED', False)),
+    'K8S_AUTOSCALER_ENABLED': str_to_bool(os.getenv('K8S_AUTOSCALER_ENABLED', False)),
     'K8S_AUTOSCALER_NAMESPACE': os.getenv('K8S_AUTOSCALER_NAMESPACE','default'),
     'K8S_AUTOSCALER_DEPLOYMENT': os.getenv('K8S_AUTOSCALER_DEPLOYMENT','cluster-autoscaler'),
     'ASG_DESIRED_STATE_TAG': 'eks-rolling-update:desired_capacity',
@@ -14,6 +18,7 @@ app_config = {
     'GLOBAL_HEALTH_WAIT': int(os.getenv('GLOBAL_HEALTH_WAIT', 20)),
     'BETWEEN_NODES_WAIT': int(os.getenv('BETWEEN_NODES_WAIT', 0)),
     'RUN_MODE': int(os.getenv('RUN_MODE', 1)),
-    'DRY_RUN': bool(os.getenv('DRY_RUN', False)),
-    'EXCLUDE_NODE_LABEL_KEY': 'spotinst.io/node-lifecycle'
+    'DRY_RUN': str_to_bool(os.getenv('DRY_RUN', False)),
+    'EXCLUDE_NODE_LABEL_KEY': 'spotinst.io/node-lifecycle',
+    'EXTRA_DRAIN_ARGS': os.getenv('EXTRA_DRAIN_ARGS', '').split()
 }


### PR DESCRIPTION
**Motivation**
There are a number of additional arguments to `drain` that would be useful to be able to control, in particular `--force=true` (to get rid of pesky standalone `Pod`s which currently break the tool, or `--grace-period` overrides etc).

Rather than add env configuration for each arg individually, it seems sensible to me to allow people to add on the to basic args already supplied that support automation.

This PR also fixes the boolean parsing within `config.py` which was incorrectly treating `export DRY_RUN=false` as Python `True` due to the way `bool(str)` works. Using `strtobool` gives [truthy style parsing](https://docs.python.org/3/distutils/apiref.html#module-distutils.util).