### PR TITLE
Make waiting for detachment of instances optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ optional arguments:
 Example:
 
 ```
-eks-rolling-update.py -c my-eks-cluster
+eks_rolling_update.py -c my-eks-cluster
 ```
 
 ## Configuration
@@ -99,6 +99,7 @@ eks-rolling-update.py -c my-eks-cluster
 | ASG_DESIRED_STATE_TAG     | Temporary tag which will be saved to the ASG to store the state of the EKS cluster prior to update                    | eks-rolling-update:desired_capacity      |
 | ASG_ORIG_CAPACITY_TAG     | Temporary tag which will be saved to the ASG to store the state of the EKS cluster prior to update                    | eks-rolling-update:original_capacity     |
 | ASG_ORIG_MAX_CAPACITY_TAG | Temporary tag which will be saved to the ASG to store the state of the EKS cluster prior to update                    | eks-rolling-update:original_max_capacity |
+| ASG_WAIT_FOR_DETACHMENT   | If True, waits for detachment to fully complete (draining connections etc) after terminating instance and detaching   | True                                     |
 | CLUSTER_HEALTH_WAIT       | Number of seconds to wait after ASG has been scaled up before checking health of the cluster                          | 90                                       |
 | GLOBAL_MAX_RETRY          | Number of attempts of a health check                                                                                  | 12                                       |
 | GLOBAL_HEALTH_WAIT        | Number of seconds to wait before retrying a health check                                                              | 20                                       |

--- a/config.py
+++ b/config.py
@@ -14,6 +14,7 @@ app_config = {
     'ASG_DESIRED_STATE_TAG': 'eks-rolling-update:desired_capacity',
     'ASG_ORIG_CAPACITY_TAG': 'eks-rolling-update:original_capacity',
     'ASG_ORIG_MAX_CAPACITY_TAG': 'eks-rolling-update:original_max_capacity',
+    'ASG_WAIT_FOR_DETACHMENT': str_to_bool(os.getenv('ASG_WAIT_FOR_DETACHMENT', True)),
     'CLUSTER_HEALTH_WAIT': int(os.getenv('CLUSTER_HEALTH_WAIT', 90)),
     'GLOBAL_MAX_RETRY': int(os.getenv('GLOBAL_MAX_RETRY', 12)),
     'GLOBAL_HEALTH_WAIT': int(os.getenv('GLOBAL_HEALTH_WAIT', 20)),

--- a/eks_rolling_update.py
+++ b/eks_rolling_update.py
@@ -99,7 +99,7 @@ def scale_up_asg(cluster_name, asg, count):
         else:
             scale_asg(asg_name, asg_old_desired_capacity, desired_capacity, asg_old_max_size)
 
-        cluster_health_wait = int(app_config['CLUSTER_HEALTH_WAIT'])
+        cluster_health_wait = app_config['CLUSTER_HEALTH_WAIT']
         logger.info(f'Waiting for {cluster_health_wait} seconds for ASG to scale before validating cluster health...')
         time.sleep(cluster_health_wait)
         asg_instance_count = count_all_cluster_instances(cluster_name)
@@ -117,7 +117,7 @@ def scale_up_asg(cluster_name, asg, count):
 
 
 def update_asgs(asgs, cluster_name):
-    run_mode = int(app_config['RUN_MODE'])
+    run_mode = app_config['RUN_MODE']
 
     asg_outdated_instance_dict = plan_asgs(asgs)
 
@@ -189,7 +189,7 @@ def update_asgs(asgs, cluster_name):
                 if app_config['ASG_WAIT_FOR_DETACHMENT'] and not instance_detached(outdated['InstanceId']):
                     raise Exception('Instance is failing to detach from ASG. Cancelling out.')
 
-                between_nodes_wait = int(app_config['BETWEEN_NODES_WAIT'])
+                between_nodes_wait = app_config['BETWEEN_NODES_WAIT']
                 if between_nodes_wait != 0:
                     logger.info(f'Waiting for {between_nodes_wait} seconds before continuing...')
                     time.sleep(between_nodes_wait)

--- a/eks_rolling_update.py
+++ b/eks_rolling_update.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 import sys
 import argparse
 import time
@@ -185,7 +186,7 @@ def update_asgs(asgs, cluster_name):
                 if not instance_terminated(outdated['InstanceId']):
                     raise Exception('Instance is failing to terminate. Cancelling out.')
                 detach_instance(outdated['InstanceId'], asg_name)
-                if not instance_detached(outdated['InstanceId']):
+                if app_config['ASG_WAIT_FOR_DETACHMENT'] and not instance_detached(outdated['InstanceId']):
                     raise Exception('Instance is failing to detach from ASG. Cancelling out.')
 
                 between_nodes_wait = int(app_config['BETWEEN_NODES_WAIT'])

--- a/lib/aws.py
+++ b/lib/aws.py
@@ -363,7 +363,7 @@ def detach_instance(instance_id, asg_name):
             ShouldDecrementDesiredCapacity=True
         )
         if response['ResponseMetadata']['HTTPStatusCode'] == requests.codes.ok:
-            logger.info('Instance detachment from ASG succeeded.')
+            logger.info('Instance detachment from ASG successfully initiated.')
         else:
             logger.info('Instance detachment from ASG failed. Response code was {}. Exiting.'.format(response['ResponseMetadata']['HTTPStatusCode']))
             raise Exception('Instance detachment from ASG failed. Response code was {}. Exiting.'.format(response['ResponseMetadata']['HTTPStatusCode']))


### PR DESCRIPTION
Fixes #22 by providing ability to disable waiting for detachment via `ASG_WAIT_FOR_DETACHMENT=false`. Default is true, same as previous behaviour.

Also made some minor code tidies to remove unnecessary casts; and add a shebang to allow the script to be run per the examples.