### PR TITLE
Add support for using ASG termination policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ eks_rolling_update.py -c my-eks-cluster
 | ASG_ORIG_CAPACITY_TAG     | Temporary tag which will be saved to the ASG to store the state of the EKS cluster prior to update                    | eks-rolling-update:original_capacity     |
 | ASG_ORIG_MAX_CAPACITY_TAG | Temporary tag which will be saved to the ASG to store the state of the EKS cluster prior to update                    | eks-rolling-update:original_max_capacity |
 | ASG_WAIT_FOR_DETACHMENT   | If True, waits for detachment to fully complete (draining connections etc) after terminating instance and detaching   | True                                     |
+| ASG_USE_TERMINATION_POLICY| Use ASG termination policy (instance terminate/detach handled by ASG according to configured termination policy)      | False                                    |
 | CLUSTER_HEALTH_WAIT       | Number of seconds to wait after ASG has been scaled up before checking health of the cluster                          | 90                                       |
 | GLOBAL_MAX_RETRY          | Number of attempts of a health check                                                                                  | 12                                       |
 | GLOBAL_HEALTH_WAIT        | Number of seconds to wait before retrying a health check                                                              | 20                                       |

--- a/config.py
+++ b/config.py
@@ -15,6 +15,7 @@ app_config = {
     'ASG_ORIG_CAPACITY_TAG': 'eks-rolling-update:original_capacity',
     'ASG_ORIG_MAX_CAPACITY_TAG': 'eks-rolling-update:original_max_capacity',
     'ASG_WAIT_FOR_DETACHMENT': str_to_bool(os.getenv('ASG_WAIT_FOR_DETACHMENT', True)),
+    'ASG_USE_TERMINATION_POLICY': str_to_bool(os.getenv('ASG_USE_TERMINATION_POLICY', False)),
     'CLUSTER_HEALTH_WAIT': int(os.getenv('CLUSTER_HEALTH_WAIT', 90)),
     'GLOBAL_MAX_RETRY': int(os.getenv('GLOBAL_MAX_RETRY', 12)),
     'GLOBAL_HEALTH_WAIT': int(os.getenv('GLOBAL_HEALTH_WAIT', 20)),

--- a/lib/aws.py
+++ b/lib/aws.py
@@ -52,7 +52,6 @@ def terminate_instance(instance_id):
         if 'DryRunOperation' not in str(e):
             raise
 
-
 def is_asg_healthy(asg_name, max_retry=app_config['GLOBAL_MAX_RETRY'], wait=app_config['GLOBAL_HEALTH_WAIT']):
     """
     Checks that all instances in an ASG have a HealthStatus of healthy. Returns False if not
@@ -339,15 +338,18 @@ def get_asg_tag(tags, tag_name):
     return result
 
 
-def count_all_cluster_instances(cluster_name):
+def count_all_cluster_instances(cluster_name, predictive=False):
     """
     Returns the total number of ec2 instances in a k8s cluster
     """
     count = 0
     asgs = get_asgs(cluster_name)
     for asg in asgs:
-        count += len(asg['Instances'])
-    logger.info("Current asg instance count in cluster is: {}. K8s node count should match this number".format(count))
+        if predictive:
+            count += asg['DesiredCapacity']
+        else:
+            count += len(asg['Instances'])
+    logger.info("{} asg instance count in cluster is: {}. K8s node count should match this number".format("*** Predicted" if predictive else "Current", count))
     return count
 
 

--- a/lib/aws.py
+++ b/lib/aws.py
@@ -52,6 +52,7 @@ def terminate_instance(instance_id):
         if 'DryRunOperation' not in str(e):
             raise
 
+
 def is_asg_healthy(asg_name, max_retry=app_config['GLOBAL_MAX_RETRY'], wait=app_config['GLOBAL_HEALTH_WAIT']):
     """
     Checks that all instances in an ASG have a HealthStatus of healthy. Returns False if not


### PR DESCRIPTION
This PR adds support for using AutoScalingGroups termination policy (see [this](https://docs.aws.amazon.com/autoscaling/ec2/userguide/as-instance-termination.html#default-termination-policy))

Reasons:
- have the option to leverage ASG termination policy to destroy older instances on scale down instead of overriding the ASG behaviour (currently, the script simulates the ASG behaviour by actually calling terminate/detach instance)
- faster upgrades -> no more time spent in terminating/detaching instances from ASG -> handled by ASG automatically (some sort of `fire-and-forget` approach)
- suitable for the majority of EKS + standard ASGs use cases where ASGs have a `Default` termination policy

Default value: `False` (disabled)

lib/aws.py changes:
- `count_all_cluster_instances` needed an alternative way of counting the instances because when using the original code, you would also get the instances that **were not yet terminated by an ASG** and this would never match k8s node count 😄 
- with `predictive` mode you know that at some point there will be as many nodes as the sum of DesiredCapacity for all ASGs
- the default behaviour of the function is the original one, so anyone using the same lib for other projects would still be able to use `count_all_cluster_instances (cluster_name)`

