### PR TITLE
Add bash back to the image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ FROM python:3-alpine3.10
 COPY --from=builder /aws-iam-authenticator /kubectl /usr/local/bin/
 COPY --from=builder /dist/*.whl /tmp
 
+RUN apk add --no-cache bash
 RUN pip3 install --no-cache-dir \
         awscli \
         /tmp/*.whl && \


### PR DESCRIPTION
The image used to have `bash`. I believe the use of multi-stage build in #36 made `bash` go away, which is a breaking change.

```sh
$ docker build --build-arg VERSION=1.0 -t rolling-update:master .
[...]
Successfully tagged rolling-update:master
$ docker run -it --entrypoint=/bin/sh rolling-update:master
/app # bash
/bin/sh: bash: not found
/app # which bash
/app # /bin/bash
/bin/sh: /bin/bash: not found
```