### PR TITLE
Adding Mode 4  (rolling nodes based on age)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,23 +1,24 @@
+FROM python:3-alpine3.10 as builder
+ARG VERSION
+RUN apk add --no-cache curl make && \
+    curl -LO  https://amazon-eks.s3-us-west-2.amazonaws.com/1.14.6/2019-08-22/bin/linux/amd64/aws-iam-authenticator && \
+    chmod +x aws-iam-authenticator && \
+    curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl && \
+    chmod +x kubectl
+
+COPY . .
+RUN make dist version=${VERSION}
+
 FROM python:3-alpine3.10
 
-RUN apk add --update --upgrade --no-cache \
-      bash \
-      curl \
-      && \
-    pip install awscli && \
-    curl -Lo /usr/local/bin/aws-iam-authenticator https://amazon-eks.s3-us-west-2.amazonaws.com/1.14.6/2019-08-22/bin/linux/amd64/aws-iam-authenticator && \
-    chmod +x /usr/local/bin/aws-iam-authenticator && \
-    curl -Lo /usr/local/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl && \
-    chmod +x /usr/local/bin/kubectl
+COPY --from=builder /aws-iam-authenticator /kubectl /usr/local/bin/
+COPY --from=builder /dist/*.whl /tmp
+
+RUN pip3 install --no-cache-dir \
+        awscli \
+        /tmp/*.whl && \
+        rm -rf /tmp/* && \
+  AWS_DEFAULT_REGION=us-east-1 eks_rolling_update.py -h
 
 WORKDIR /app
-
-COPY requirements.txt .
-
-RUN pip3 install --no-cache-dir -r requirements.txt
-
-COPY eksrollup ./eksrollup
-
-COPY eks_rolling_update.py ./
-
-ENTRYPOINT ["python", "eks_rolling_update.py"]
+ENTRYPOINT ["eks_rolling_update.py"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,24 +1,23 @@
-FROM python:3-alpine3.10 as builder
-ARG VERSION
-RUN apk add --no-cache curl make && \
-    curl -LO  https://amazon-eks.s3-us-west-2.amazonaws.com/1.14.6/2019-08-22/bin/linux/amd64/aws-iam-authenticator && \
-    chmod +x aws-iam-authenticator && \
-    curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl && \
-    chmod +x kubectl
-
-COPY . .
-RUN make dist version=${VERSION}
-
 FROM python:3-alpine3.10
 
-COPY --from=builder /aws-iam-authenticator /kubectl /usr/local/bin/
-COPY --from=builder /dist/*.whl /tmp
-
-RUN pip3 install --no-cache-dir \
-        awscli \
-        /tmp/*.whl && \
-        rm -rf /tmp/* && \
-  AWS_DEFAULT_REGION=us-east-1 eks_rolling_update.py -h
+RUN apk add --update --upgrade --no-cache \
+      bash \
+      curl \
+      && \
+    pip install awscli && \
+    curl -Lo /usr/local/bin/aws-iam-authenticator https://amazon-eks.s3-us-west-2.amazonaws.com/1.14.6/2019-08-22/bin/linux/amd64/aws-iam-authenticator && \
+    chmod +x /usr/local/bin/aws-iam-authenticator && \
+    curl -Lo /usr/local/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl && \
+    chmod +x /usr/local/bin/kubectl
 
 WORKDIR /app
-ENTRYPOINT ["eks_rolling_update.py"]
+
+COPY requirements.txt .
+
+RUN pip3 install --no-cache-dir -r requirements.txt
+
+COPY eksrollup ./eksrollup
+
+COPY eks_rolling_update.py ./
+
+ENTRYPOINT ["python", "eks_rolling_update.py"]

--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ eks_rolling_update.py -c my-eks-cluster
 | RUN_MODE                  | See Run Modes section below                                                                                           | 1                                        |
 | DRY_RUN                   | If True, only a query will be run to determine which worker nodes are outdated without running an update operation    | False                                    |
 | EXTRA_DRAIN_ARGS          | Additional space-delimited args to supply to the `kubectl drain` function, e.g `--force=true`. See `kubectl drain -h` | ""                                       |
+| MAX_ALLOWABLE_NODE_AGE    | The max age each node allowed to be. This works with `RUN_MODE` 4 as node rolling is updating based on age of node.      | 6                                          |
 
 ## Run Modes
 There are a number of different values which can be set for the `RUN_MODE` environment variable.
@@ -115,6 +116,8 @@ There are a number of different values which can be set for the `RUN_MODE` envir
 | 1             | Scale up and cordon the outdated nodes of each ASG one-by-one, just before we drain them.       |
 | 2             | Scale up and cordon the outdated nodes of all ASGs all at once at the beginning of the run.     |
 | 3             | Cordon the outdated nodes of all ASGs at the beginning of the run but scale each ASG one-by-one.|
+| 4             | Roll EKS nodes based on age instead of launch config (works with `MAX_ALLOWABLE_NODE_AGE` with default 6 days value). |
+
 
 Each of them have different advantages and disadvantages.
 * Scaling up all ASGs at once may cause AWS EC2 instance limits to be exceeded

--- a/eksrollup/cli.py
+++ b/eksrollup/cli.py
@@ -165,7 +165,7 @@ def update_asgs(asgs, cluster_name):
                 f'Setting the scale of ASG {asg_name} based on {outdated_instance_count} outdated instances.')
             asg_original_state_dict[asg_name] = scale_up_asg(cluster_name, asg, outdated_instance_count)
 
-        if (run_mode == 1) or (run_mode == 4):
+        if (run_mode == 1)  or (run_mode == 4):
             for outdated in outdated_instances:
                 node_name = ""
                 try:

--- a/eksrollup/cli.py
+++ b/eksrollup/cli.py
@@ -5,7 +5,7 @@ import shutil
 from .config import app_config
 from .lib.logger import logger
 from .lib.aws import is_asg_scaled, is_asg_healthy, instance_terminated, get_asg_tag, modify_aws_autoscaling, \
-    count_all_cluster_instances, save_asg_tags, get_asgs, scale_asg, plan_asgs, terminate_instance_in_asg, delete_asg_tags
+    count_all_cluster_instances, save_asg_tags, get_asgs, scale_asg, plan_asgs, terminate_instance_in_asg, delete_asg_tags, plan_asgs_older_nodes
 from .lib.k8s import k8s_nodes_count, k8s_nodes_ready, get_k8s_nodes, modify_k8s_autoscaler, get_node_by_instance_id, \
     drain_node, delete_node, cordon_node
 from .lib.exceptions import RollingUpdateException
@@ -122,7 +122,12 @@ def scale_up_asg(cluster_name, asg, count):
 def update_asgs(asgs, cluster_name):
     run_mode = app_config['RUN_MODE']
     use_asg_termination_policy = app_config['ASG_USE_TERMINATION_POLICY']
-    asg_outdated_instance_dict = plan_asgs(asgs)
+
+    if run_mode == 4:
+        asg_outdated_instance_dict = plan_asgs_older_nodes(asgs)
+
+    else:
+        asg_outdated_instance_dict = plan_asgs(asgs)
 
     asg_original_state_dict = {}
 
@@ -155,12 +160,12 @@ def update_asgs(asgs, cluster_name):
         outdated_instances, asg = asg_tuple
         outdated_instance_count = len(outdated_instances)
 
-        if (run_mode == 1) or (run_mode == 3):
+        if (run_mode == 1) or (run_mode == 3) or (run_mode == 4):
             logger.info(
                 f'Setting the scale of ASG {asg_name} based on {outdated_instance_count} outdated instances.')
             asg_original_state_dict[asg_name] = scale_up_asg(cluster_name, asg, outdated_instance_count)
 
-        if run_mode == 1:
+        if (run_mode == 1)  or (run_mode == 4):
             for outdated in outdated_instances:
                 node_name = ""
                 try:
@@ -228,8 +233,12 @@ def main(args=None):
         logger.info('kubectl is required to be installed before proceeding')
         quit(1)
     filtered_asgs = get_asgs(args.cluster_name)
-    # perform a dry run
-    if args.plan:
+    run_mode = app_config['RUN_MODE']
+    # perform a dry run on mode 4 for older nodes
+    if args.plan and (run_mode == 4):
+        plan_asgs_older_nodes(filtered_asgs)
+    # perform a dry run on main mode
+    elif args.plan:
         plan_asgs(filtered_asgs)
     else:
         # perform real update

--- a/eksrollup/cli.py
+++ b/eksrollup/cli.py
@@ -165,7 +165,7 @@ def update_asgs(asgs, cluster_name):
                 f'Setting the scale of ASG {asg_name} based on {outdated_instance_count} outdated instances.')
             asg_original_state_dict[asg_name] = scale_up_asg(cluster_name, asg, outdated_instance_count)
 
-        if (run_mode == 1)  or (run_mode == 4):
+        if (run_mode == 1) or (run_mode == 4):
             for outdated in outdated_instances:
                 node_name = ""
                 try:

--- a/eksrollup/config.py
+++ b/eksrollup/config.py
@@ -25,5 +25,6 @@ app_config = {
     'RUN_MODE': int(os.getenv('RUN_MODE', 1)),
     'DRY_RUN': str_to_bool(os.getenv('DRY_RUN', False)),
     'EXCLUDE_NODE_LABEL_KEY': 'spotinst.io/node-lifecycle',
-    'EXTRA_DRAIN_ARGS': os.getenv('EXTRA_DRAIN_ARGS', '').split()
+    'EXTRA_DRAIN_ARGS': os.getenv('EXTRA_DRAIN_ARGS', '').split(),
+    'MAX_ALLOWABLE_NODE_AGE': int(os.getenv('MAX_ALLOWABLE_NODE_AGE', 6))
 }

--- a/eksrollup/lib/aws.py
+++ b/eksrollup/lib/aws.py
@@ -258,10 +258,8 @@ def instance_outdated_launchtemplate(instance_obj, asg_lt_name, asg_lt_version):
     return False
 
 
-def instance_outdated_age(instance_id, days_fresh):
-    """
-    Checks the age of an instance against the MAX_ALLOWABLE_NODE_AGE.
-    """
+def instance_outdated_age (instance_id, days_fresh):
+
     response = ec2_client.describe_instances(
         InstanceIds=[
             instance_id,
@@ -270,10 +268,10 @@ def instance_outdated_age(instance_id, days_fresh):
 
     instance_launch_time = response['Reservations'][0]['Instances'][0]['LaunchTime']
 
-    # gets the age of a node by days only:
+    #gets the age of a node by days only:
     instance_age = ((datetime.datetime.now(instance_launch_time.tzinfo) - instance_launch_time).days)
 
-    # gets the remaining age of a node in seconds (e.g. if node is y days and x seconds old this will only retrieve the x seconds):
+    #gets the remaining age of a node in seconds (e.g. if node is y days and x seconds old this will only retrieve the x seconds):
     instance_age_remainder = ((datetime.datetime.now(instance_launch_time.tzinfo) - instance_launch_time).seconds)
 
     if instance_age > days_fresh:
@@ -374,7 +372,7 @@ def plan_asgs_older_nodes(asgs):
         outdated_instances = []
         for instance in instances:
             if instance_outdated_age(instance['InstanceId'], days_fresh):
-                outdated_instances.append(instance)
+                    outdated_instances.append(instance)
         logger.info('Found {} outdated instances'.format(
             len(outdated_instances))
         )

--- a/eksrollup/lib/aws.py
+++ b/eksrollup/lib/aws.py
@@ -258,8 +258,10 @@ def instance_outdated_launchtemplate(instance_obj, asg_lt_name, asg_lt_version):
     return False
 
 
-def instance_outdated_age (instance_id, days_fresh):
-
+def instance_outdated_age(instance_id, days_fresh):
+    """
+    Checks the age of an instance against the MAX_ALLOWABLE_NODE_AGE.
+    """
     response = ec2_client.describe_instances(
         InstanceIds=[
             instance_id,
@@ -268,10 +270,10 @@ def instance_outdated_age (instance_id, days_fresh):
 
     instance_launch_time = response['Reservations'][0]['Instances'][0]['LaunchTime']
 
-    #gets the age of a node by days only:
+    # gets the age of a node by days only:
     instance_age = ((datetime.datetime.now(instance_launch_time.tzinfo) - instance_launch_time).days)
 
-    #gets the remaining age of a node in seconds (e.g. if node is y days and x seconds old this will only retrieve the x seconds):
+    # gets the remaining age of a node in seconds (e.g. if node is y days and x seconds old this will only retrieve the x seconds):
     instance_age_remainder = ((datetime.datetime.now(instance_launch_time.tzinfo) - instance_launch_time).seconds)
 
     if instance_age > days_fresh:
@@ -372,7 +374,7 @@ def plan_asgs_older_nodes(asgs):
         outdated_instances = []
         for instance in instances:
             if instance_outdated_age(instance['InstanceId'], days_fresh):
-                    outdated_instances.append(instance)
+                outdated_instances.append(instance)
         logger.info('Found {} outdated instances'.format(
             len(outdated_instances))
         )

--- a/eksrollup/lib/aws.py
+++ b/eksrollup/lib/aws.py
@@ -258,7 +258,10 @@ def instance_outdated_launchtemplate(instance_obj, asg_lt_name, asg_lt_version):
     return False
 
 
-def instance_outdated_age (instance_id, days_fresh):
+def instance_outdated_age(instance_id, days_fresh):
+    """
+    Checks the age of an instance against the MAX_ALLOWABLE_NODE_AGE.
+    """
 
     response = ec2_client.describe_instances(
         InstanceIds=[
@@ -268,10 +271,10 @@ def instance_outdated_age (instance_id, days_fresh):
 
     instance_launch_time = response['Reservations'][0]['Instances'][0]['LaunchTime']
 
-    #gets the age of a node by days only:
+    # gets the age of a node by days only:
     instance_age = ((datetime.datetime.now(instance_launch_time.tzinfo) - instance_launch_time).days)
 
-    #gets the remaining age of a node in seconds (e.g. if node is y days and x seconds old this will only retrieve the x seconds):
+    # gets the remaining age of a node in seconds (e.g. if node is y days and x seconds old this will only retrieve the x seconds):
     instance_age_remainder = ((datetime.datetime.now(instance_launch_time.tzinfo) - instance_launch_time).seconds)
 
     if instance_age > days_fresh:
@@ -372,7 +375,7 @@ def plan_asgs_older_nodes(asgs):
         outdated_instances = []
         for instance in instances:
             if instance_outdated_age(instance['InstanceId'], days_fresh):
-                    outdated_instances.append(instance)
+                outdated_instances.append(instance)
         logger.info('Found {} outdated instances'.format(
             len(outdated_instances))
         )


### PR DESCRIPTION
@crhuber This is a continuation of splitting #35 into multiple PRs.

This PR adds a mode 4 to the script which aims to roll nodes based on each ec2 instance's age (i.e. roll nodes older than x days). A new variable is added `MAX_ALLOWABLE_NODE_AGE` which defaults to 6 days as part of this new mode. The new mode checks for each instance launch date and replaces nodes older than `MAX_ALLOWABLE_NODE_AGE`. The purpose behind this is to ensure nodes running in a cluster are consistently refreshed regardless of configuration changes. 

Mode 4 follows the same pattern as mode 1 in order of execution: scale up and cordon the outdated nodes of each ASG one-by-one, before each is drained. 
