### PR TITLE
Allow user to configure EXCLUDE_NODE_LABEL_KEYS

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ eks_rolling_update.py -c my-eks-cluster
 | BETWEEN_NODES_WAIT        | Number of seconds to wait after removing a node before continuing on                                                  | 0                                        |
 | RUN_MODE                  | See Run Modes section below                                                                                           | 1                                        |
 | DRY_RUN                   | If True, only a query will be run to determine which worker nodes are outdated without running an update operation    | False                                    |
+| EXCLUDE_NODE_LABEL_KEYS   | List of space-delimited keys for node labels. Nodes with a label using one of these keys will be excluded from the node count when scaling the cluster. | "spotinst.io/node-lifecycle" |
 | EXTRA_DRAIN_ARGS          | Additional space-delimited args to supply to the `kubectl drain` function, e.g `--force=true`. See `kubectl drain -h` | ""                                       |
 | MAX_ALLOWABLE_NODE_AGE    | The max age each node allowed to be. This works with `RUN_MODE` 4 as node rolling is updating based on age of node.      | 6                                          |
 

--- a/eksrollup/config.py
+++ b/eksrollup/config.py
@@ -24,7 +24,7 @@ app_config = {
     'BETWEEN_NODES_WAIT': int(os.getenv('BETWEEN_NODES_WAIT', 0)),
     'RUN_MODE': int(os.getenv('RUN_MODE', 1)),
     'DRY_RUN': str_to_bool(os.getenv('DRY_RUN', False)),
-    'EXCLUDE_NODE_LABEL_KEY': 'spotinst.io/node-lifecycle',
+    'EXCLUDE_NODE_LABEL_KEYS': os.getenv('EXCLUDE_NODE_LABEL_KEYS', 'spotinst.io/node-lifecycle').split(),
     'EXTRA_DRAIN_ARGS': os.getenv('EXTRA_DRAIN_ARGS', '').split(),
     'MAX_ALLOWABLE_NODE_AGE': int(os.getenv('MAX_ALLOWABLE_NODE_AGE', 6))
 }

--- a/eksrollup/lib/k8s.py
+++ b/eksrollup/lib/k8s.py
@@ -7,7 +7,7 @@ from .logger import logger
 from eksrollup.config import app_config
 
 
-def get_k8s_nodes(exclude_node_label_key=app_config["EXCLUDE_NODE_LABEL_KEY"]):
+def get_k8s_nodes(exclude_node_label_keys=app_config["EXCLUDE_NODE_LABEL_KEYS"]):
     """
     Returns a list of kubernetes nodes
     """
@@ -23,10 +23,10 @@ def get_k8s_nodes(exclude_node_label_key=app_config["EXCLUDE_NODE_LABEL_KEY"]):
     k8s_api = client.CoreV1Api()
     logger.info("Getting k8s nodes...")
     response = k8s_api.list_node()
-    if exclude_node_label_key is not None:
+    if exclude_node_label_keys is not None:
         nodes = []
         for node in response.items:
-            if exclude_node_label_key not in node.metadata.labels:
+            if all(key not in node.metadata.labels for key in exclude_node_label_keys):
                 nodes.append(node)
         response.items = nodes
     logger.info("Current k8s node count is {}".format(len(response.items)))


### PR DESCRIPTION
We have nodes in our cluster which do not belong to any autoscaling group, and need to be excluded from the node count when checking if the cluster is still healthy. Therefore, we need the EXCLUDE_NODE_LABEL_KEY configuration to be configurable when we execute the script.