### PR TITLE
adding environment variable CLUSTER_HEALTH_RETRY to allow x amount of…

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,8 +98,8 @@ eks_rolling_update.py -c my-eks-cluster
 | ASG_WAIT_FOR_DETACHMENT   | If True, waits for detachment to fully complete (draining connections etc) after terminating instance and detaching   | True                                     |
 | ASG_USE_TERMINATION_POLICY| Use ASG termination policy (instance terminate/detach handled by ASG according to configured termination policy)      | False                                    |
 | CLUSTER_HEALTH_WAIT       | Number of seconds to wait after ASG has been scaled up before checking health of the cluster                          | 90                                       |
-| CLUSTER_HEALTH_RETRY      | Number of attempts to validate the health of the cluster                                                              | 1                                        |
-| GLOBAL_MAX_RETRY          | Number of attempts of a health check                                                                                  | 12                                       |
+| CLUSTER_HEALTH_RETRY      | Number of attempts to validate the health of the cluster after ASG has been scaled                                    | 1                                        |
+| GLOBAL_MAX_RETRY          | Number of attempts of a health or termination check                                                                   | 12                                       |
 | GLOBAL_HEALTH_WAIT        | Number of seconds to wait before retrying a health check                                                              | 20                                       |
 | BETWEEN_NODES_WAIT        | Number of seconds to wait after removing a node before continuing on                                                  | 0                                        |
 | RUN_MODE                  | See Run Modes section below                                                                                           | 1                                        |

--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ eks_rolling_update.py -c my-eks-cluster
 | ASG_WAIT_FOR_DETACHMENT   | If True, waits for detachment to fully complete (draining connections etc) after terminating instance and detaching   | True                                     |
 | ASG_USE_TERMINATION_POLICY| Use ASG termination policy (instance terminate/detach handled by ASG according to configured termination policy)      | False                                    |
 | CLUSTER_HEALTH_WAIT       | Number of seconds to wait after ASG has been scaled up before checking health of the cluster                          | 90                                       |
+| CLUSTER_HEALTH_RETRY      | Number of attempts to validate the health of the cluster                                                              | 1                                        |
 | GLOBAL_MAX_RETRY          | Number of attempts of a health check                                                                                  | 12                                       |
 | GLOBAL_HEALTH_WAIT        | Number of seconds to wait before retrying a health check                                                              | 20                                       |
 | BETWEEN_NODES_WAIT        | Number of seconds to wait after removing a node before continuing on                                                  | 0                                        |

--- a/eksrollup/cli.py
+++ b/eksrollup/cli.py
@@ -15,11 +15,11 @@ def validate_cluster_health(asg_name, new_desired_asg_capacity, cluster_name, pr
     cluster_health_retry = app_config['CLUSTER_HEALTH_RETRY']
     cluster_health_wait = app_config['CLUSTER_HEALTH_WAIT']
     cluster_healthy = False
-    nodes_ready = False
     retry_count = 0
 
     while retry_count < cluster_health_retry:
         retry_count += 1
+        node_count_mismatch = False
         if health_check_type == "asg":
             logger.info(f'Waiting for {cluster_health_wait} seconds for ASG to scale before validating cluster health...')
         else:
@@ -36,7 +36,6 @@ def validate_cluster_health(asg_name, new_desired_asg_capacity, cluster_name, pr
                 if k8s_nodes_count(desired_k8s_node_count):
                     # check k8s nodes are healthy
                     if k8s_nodes_ready():
-                        nodes_ready = True
                         cluster_healthy = True
                         break
                 else:
@@ -46,14 +45,13 @@ def validate_cluster_health(asg_name, new_desired_asg_capacity, cluster_name, pr
 
     if cluster_healthy:
         logger.info('Cluster validation passed. Proceeding with node draining and termination...')
-    elif not nodes_ready:
-        logger.info('Validation failed for cluster. Expected node count reached but nodes are not healthy.')
     elif node_count_mismatch:
         nodes = get_k8s_nodes()
-        logger.info('Current k8s node count is {}'.format(len(nodes)))
         logger.info('Validation failed for cluster. Current node count {} Expected node count {}.'.format(
             len(nodes),
             desired_k8s_node_count))
+    elif not cluster_healthy:
+        logger.info('Validation failed for cluster. Expected node count reached but nodes are not healthy.')
     else:
         logger.info(
             'Validation failed for asg {}.'
@@ -62,8 +60,6 @@ def validate_cluster_health(asg_name, new_desired_asg_capacity, cluster_name, pr
     if not cluster_healthy:
         logger.info('Exiting since ASG healthcheck failed')
         raise Exception('ASG healthcheck failed')
-
-    return cluster_healthy
 
 
 def scale_up_asg(cluster_name, asg, count):
@@ -124,7 +120,6 @@ def scale_up_asg(cluster_name, asg, count):
             scale_asg(asg_name, asg_old_desired_capacity, desired_capacity, desired_capacity)
         else:
             scale_asg(asg_name, asg_old_desired_capacity, desired_capacity, asg_old_max_size)
-
 
         # check cluster health before doing anything
         validate_cluster_health(

--- a/eksrollup/cli.py
+++ b/eksrollup/cli.py
@@ -11,32 +11,58 @@ from .lib.k8s import k8s_nodes_count, k8s_nodes_ready, get_k8s_nodes, modify_k8s
 from .lib.exceptions import RollingUpdateException
 
 
-def validate_cluster_health(asg_name, new_desired_asg_capacity, desired_k8s_node_count, ):
+def validate_cluster_health(asg_name, new_desired_asg_capacity, cluster_name, predictive, health_check_type="regular",):
+    cluster_health_retry = app_config['CLUSTER_HEALTH_RETRY']
+    cluster_health_wait = app_config['CLUSTER_HEALTH_WAIT']
     cluster_healthy = False
-    # check if asg has enough nodes first before checking instance health
-    if is_asg_scaled(asg_name, new_desired_asg_capacity):
-        # if asg is healthy start draining and terminating instances
-        if is_asg_healthy(asg_name):
-            # check if k8s nodes are all online
-            if k8s_nodes_count(desired_k8s_node_count):
-                # check k8s nodes are healthy
-                if k8s_nodes_ready():
-                    logger.info('Cluster validation passed. Proceeding with node draining and termination...')
-                    cluster_healthy = True
-                else:
-                    logger.info('Validation failed for cluster. Expected node count reached but nodes are not healthy.')
-            else:
-                nodes = get_k8s_nodes()
-                logger.info('Current k8s node count is {}'.format(len(nodes)))
-                logger.info('Validation failed for cluster. Current node count {} Expected node count {}.'.format(
-                    len(nodes),
-                    desired_k8s_node_count))
+    nodes_ready = False
+    retry_count = 0
+
+    while retry_count < cluster_health_retry:
+        retry_count += 1
+        if health_check_type == "asg":
+            logger.info(f'Waiting for {cluster_health_wait} seconds for ASG to scale before validating cluster health...')
         else:
-            logger.info(
-                'Validation failed for asg {}.'
-                'Instances not healthy'.format(asg_name))
+            logger.info(f'Waiting for {cluster_health_wait} seconds before validating cluster health...')
+
+        time.sleep(cluster_health_wait)
+        desired_k8s_node_count = count_all_cluster_instances(cluster_name, predictive=predictive)
+
+        # check if asg has enough nodes first before checking instance health
+        if is_asg_scaled(asg_name, new_desired_asg_capacity):
+            # if asg is healthy start draining and terminating instances
+            if is_asg_healthy(asg_name):
+                # check if k8s nodes are all online and with the matches the desired amount of instances
+                if k8s_nodes_count(desired_k8s_node_count):
+                    # check k8s nodes are healthy
+                    if k8s_nodes_ready():
+                        nodes_ready = True
+                        cluster_healthy = True
+                        break
+                else:
+                    node_count_mismatch = True
+        else:
+            logger.info('Validation failed for asg {}. Not enough instances online.'.format(asg_name))
+
+    if cluster_healthy:
+        logger.info('Cluster validation passed. Proceeding with node draining and termination...')
+    elif not nodes_ready:
+        logger.info('Validation failed for cluster. Expected node count reached but nodes are not healthy.')
+    elif node_count_mismatch:
+        nodes = get_k8s_nodes()
+        logger.info('Current k8s node count is {}'.format(len(nodes)))
+        logger.info('Validation failed for cluster. Current node count {} Expected node count {}.'.format(
+            len(nodes),
+            desired_k8s_node_count))
     else:
-        logger.info('Validation failed for asg {}. Not enough instances online.'.format(asg_name))
+        logger.info(
+            'Validation failed for asg {}.'
+            'Instances not healthy'.format(asg_name))
+
+    if not cluster_healthy:
+        logger.info('Exiting since ASG healthcheck failed')
+        raise Exception('ASG healthcheck failed')
+
     return cluster_healthy
 
 
@@ -77,16 +103,13 @@ def scale_up_asg(cluster_name, asg, count):
         logger.info('Found previous desired capacity value tag set on asg from a previous run.')
         logger.info(f'Maintaining previous capacity of {asg_old_desired_capacity} to not overscale.')
 
-        asg_instance_count = count_all_cluster_instances(cluster_name, predictive=predictive)
-
         # check cluster health before doing anything
-        if not validate_cluster_health(
+        validate_cluster_health(
             asg_name,
             int(asg_tag_desired_capacity.get('Value')),
-            asg_instance_count
-        ):
-            logger.info('Exiting since ASG healthcheck failed')
-            raise Exception('ASG healthcheck failed')
+            cluster_name,
+            predictive
+        )
 
         return int(asg_tag_desired_capacity.get('Value')), int(asg_tag_orig_capacity.get(
             'Value')), int(asg_tag_orig_max_capacity.get('Value'))
@@ -102,19 +125,15 @@ def scale_up_asg(cluster_name, asg, count):
         else:
             scale_asg(asg_name, asg_old_desired_capacity, desired_capacity, asg_old_max_size)
 
-        cluster_health_wait = app_config['CLUSTER_HEALTH_WAIT']
-        logger.info(f'Waiting for {cluster_health_wait} seconds for ASG to scale before validating cluster health...')
-        time.sleep(cluster_health_wait)
-        asg_instance_count = count_all_cluster_instances(cluster_name, predictive=predictive)
 
         # check cluster health before doing anything
-        if not validate_cluster_health(
+        validate_cluster_health(
             asg_name,
             desired_capacity,
-            asg_instance_count
-        ):
-            logger.info('Exiting since ASG healthcheck failed')
-            raise Exception('ASG healthcheck failed')
+            cluster_name,
+            predictive,
+            health_check_type="asg"
+        )
 
         return desired_capacity, asg_old_desired_capacity, asg_old_max_size
 

--- a/eksrollup/config.py
+++ b/eksrollup/config.py
@@ -19,6 +19,7 @@ app_config = {
     'ASG_WAIT_FOR_DETACHMENT': str_to_bool(os.getenv('ASG_WAIT_FOR_DETACHMENT', True)),
     'ASG_USE_TERMINATION_POLICY': str_to_bool(os.getenv('ASG_USE_TERMINATION_POLICY', False)),
     'CLUSTER_HEALTH_WAIT': int(os.getenv('CLUSTER_HEALTH_WAIT', 90)),
+    'CLUSTER_HEALTH_RETRY': int(os.getenv('CLUSTER_HEALTH_RETRY', 1)),
     'GLOBAL_MAX_RETRY': int(os.getenv('GLOBAL_MAX_RETRY', 12)),
     'GLOBAL_HEALTH_WAIT': int(os.getenv('GLOBAL_HEALTH_WAIT', 20)),
     'BETWEEN_NODES_WAIT': int(os.getenv('BETWEEN_NODES_WAIT', 0)),


### PR DESCRIPTION
In order to address the Feature Request '[Feature] Timeout waiting for instance scale up
#55':
![Screen Shot 2020-08-29 at 12 22 31 AM](https://user-images.githubusercontent.com/14078699/91631350-bedc7180-e98d-11ea-958d-ae1cbaaac0fd.png)

I also updated the documentation to address #54

I have added the environment variable CLUSTER_HEALTH_RETRY to allow x amount of retries(specified by the user) of a cluster health check after an ASG Scaling. For some people it make take longer than 90 seconds for there instances to spin up but also by making this change it also can speed up the change for many people. So we can set the CLUSTER_HEALTH_WAIT to only 5 seconds for example and set CLUSTER_HEALTH_RETRY to 40. So the max time it will try is 200 seconds in this scenario but it's possible that it can finish within 20 second, setting it up this way can work for those times when more time is needed and other times when the scale up happens quickly. I also made sure that by default it still runs only once and still uses the wait time of 90 seconds in case people who are already using it like the way it is.

Heres an example snippet of it running and working:
-------------------------------------
2020-08-29 00:13:49,640 INFO     Setting asg desired capacity from 1 to 2 and max size to 20...
2020-08-29 00:13:49,836 INFO     Waiting for 5 seconds for ASG to scale before validating cluster health...

2020-08-29 00:13:54,841 INFO     Describing autoscaling groups...
2020-08-29 00:13:55,390 INFO     Current asg instance count in cluster is: 9. K8s node count should match this number
2020-08-29 00:13:55,390 INFO     Checking asg eks-test-workers-2-spot instance count...
2020-08-29 00:13:55,504 INFO     Asg eks-test-workers-2-spot does not have enough running instances to proceed
2020-08-29 00:13:55,504 INFO     Actual instances: 1 Desired instances: 2
2020-08-29 00:13:55,504 INFO     Validation failed for asg eks-test-workers-2-spot. Not enough instances online.
2020-08-29 00:13:55,504 INFO     Waiting for 5 seconds for ASG to scale before validating cluster health...

2020-08-29 00:14:00,506 INFO     Describing autoscaling groups...
2020-08-29 00:14:01,158 INFO     Current asg instance count in cluster is: 9. K8s node count should match this number
2020-08-29 00:14:01,158 INFO     Checking asg eks-test-workers-2-spot instance count...
2020-08-29 00:14:01,280 INFO     Asg eks-test-workers-2-spot does not have enough running instances to proceed
2020-08-29 00:14:01,280 INFO     Actual instances: 1 Desired instances: 2
2020-08-29 00:14:01,281 INFO     Validation failed for asg eks-test-workers-2-spot. Not enough instances online.
2020-08-29 00:14:01,281 INFO     Waiting for 5 seconds for ASG to scale before validating cluster health...

2020-08-29 00:14:06,285 INFO     Describing autoscaling groups...
2020-08-29 00:14:06,778 INFO     Current asg instance count in cluster is: 9. K8s node count should match this number
2020-08-29 00:14:06,778 INFO     Checking asg eks-test-workers-2-spot instance count...
2020-08-29 00:14:06,930 INFO     Asg eks-test-workers-2-spot does not have enough running instances to proceed
2020-08-29 00:14:06,930 INFO     Actual instances: 1 Desired instances: 2
2020-08-29 00:14:06,931 INFO     Validation failed for asg eks-test-workers-2-spot. Not enough instances online.
2020-08-29 00:14:06,931 INFO     Waiting for 5 seconds for ASG to scale before validating cluster health...

2020-08-29 00:14:11,931 INFO     Describing autoscaling groups...
2020-08-29 00:14:12,493 INFO     Current asg instance count in cluster is: 9. K8s node count should match this number
2020-08-29 00:14:12,493 INFO     Checking asg eks-test-workers-2-spot instance count...
2020-08-29 00:14:12,596 INFO     Asg eks-test-workers-2-spot does not have enough running instances to proceed
2020-08-29 00:14:12,596 INFO     Actual instances: 1 Desired instances: 2
2020-08-29 00:14:12,597 INFO     Validation failed for asg eks-test-workers-2-spot. Not enough instances online.
2020-08-29 00:14:12,597 INFO     Waiting for 5 seconds for ASG to scale before validating cluster health...

2020-08-29 00:14:17,601 INFO     Describing autoscaling groups...
2020-08-29 00:14:18,145 INFO     Current asg instance count in cluster is: 10. K8s node count should match this number
2020-08-29 00:14:18,145 INFO     Checking asg eks-test-workers-2-spot instance count...
2020-08-29 00:14:18,249 INFO     Asg eks-test-workers-2-spot scaled OK
2020-08-29 00:14:18,250 INFO     Actual instances: 2 Desired instances: 2
2020-08-29 00:14:18,250 INFO     Checking asg eks-test-workers-2-spot instance health...
2020-08-29 00:14:18,350 INFO     Instance i-06b896811187d6cc0 - Healthy
2020-08-29 00:14:18,350 INFO     Instance i-0be321879567e30aa - Healthy
-------------------------------------
