### PR TITLE
feat: allow user to override termination check

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,29 +102,31 @@ eks_rolling_update.py -c my-eks-cluster
 
 ## Configuration
 
-| Environment Variable      | Description                                                                                                           | Default                                  |
-|---------------------------|-----------------------------------------------------------------------------------------------------------------------|------------------------------------------|
-| K8S_AUTOSCALER_ENABLED    | If True Kubernetes Autoscaler will be paused before running update                                                    | False                                    |
-| K8S_AUTOSCALER_NAMESPACE  | Namespace where Kubernetes Autoscaler is deployed                                                                     | "default"                                |
-| K8S_AUTOSCALER_DEPLOYMENT | Deployment name of Kubernetes Autoscaler                                                                              | "cluster-autoscaler"                     |
-| K8S_AUTOSCALER_REPLICAS   | Number of replicas to scale back up to after Kubernentes Autoscaler paused                                            | 2                                        |
-| ASG_DESIRED_STATE_TAG     | Temporary tag which will be saved to the ASG to store the state of the EKS cluster prior to update                    | eks-rolling-update:desired_capacity      |
-| ASG_ORIG_CAPACITY_TAG     | Temporary tag which will be saved to the ASG to store the state of the EKS cluster prior to update                    | eks-rolling-update:original_capacity     |
-| ASG_ORIG_MAX_CAPACITY_TAG | Temporary tag which will be saved to the ASG to store the state of the EKS cluster prior to update                    | eks-rolling-update:original_max_capacity |
-| ASG_WAIT_FOR_DETACHMENT   | If True, waits for detachment to fully complete (draining connections etc) after terminating instance and detaching   | True                                     |
-| ASG_USE_TERMINATION_POLICY| Use ASG termination policy (instance terminate/detach handled by ASG according to configured termination policy)      | False                                    |
-| CLUSTER_HEALTH_WAIT       | Number of seconds to wait after ASG has been scaled up before checking health of the cluster                          | 90                                       |
-| CLUSTER_HEALTH_RETRY      | Number of attempts to validate the health of the cluster after ASG has been scaled                                    | 1                                        |
-| GLOBAL_MAX_RETRY          | Number of attempts of a health or termination check                                                                   | 12                                       |
-| GLOBAL_HEALTH_WAIT        | Number of seconds to wait before retrying a health check                                                              | 20                                       |
-| BETWEEN_NODES_WAIT        | Number of seconds to wait after removing a node before continuing on                                                  | 0                                        |
-| RUN_MODE                  | See Run Modes section below                                                                                           | 1                                        |
-| DRY_RUN                   | If True, only a query will be run to determine which worker nodes are outdated without running an update operation    | False                                    |
-| EXCLUDE_NODE_LABEL_KEYS   | List of space-delimited keys for node labels. Nodes with a label using one of these keys will be excluded from the node count when scaling the cluster. | "spotinst.io/node-lifecycle" |
-| EXTRA_DRAIN_ARGS          | Additional space-delimited args to supply to the `kubectl drain` function, e.g `--force=true`. See `kubectl drain -h` | ""                                       |
-| MAX_ALLOWABLE_NODE_AGE    | The max age each node allowed to be. This works with `RUN_MODE` 4 as node rolling is updating based on age of node.      | 6                                          |
+| Environment Variable       | Description                                                                                                           | Default                                  |
+|----------------------------|-----------------------------------------------------------------------------------------------------------------------|------------------------------------------|
+| K8S_AUTOSCALER_ENABLED     | If True Kubernetes Autoscaler will be paused before running update                                                    | False                                    |
+| K8S_AUTOSCALER_NAMESPACE   | Namespace where Kubernetes Autoscaler is deployed                                                                     | "default"                                |
+| K8S_AUTOSCALER_DEPLOYMENT  | Deployment name of Kubernetes Autoscaler                                                                              | "cluster-autoscaler"                     |
+| K8S_AUTOSCALER_REPLICAS    | Number of replicas to scale back up to after Kubernentes Autoscaler paused                                            | 2                                        |
+| ASG_DESIRED_STATE_TAG      | Temporary tag which will be saved to the ASG to store the state of the EKS cluster prior to update                    | eks-rolling-update:desired_capacity      |
+| ASG_ORIG_CAPACITY_TAG      | Temporary tag which will be saved to the ASG to store the state of the EKS cluster prior to update                    | eks-rolling-update:original_capacity     |
+| ASG_ORIG_MAX_CAPACITY_TAG  | Temporary tag which will be saved to the ASG to store the state of the EKS cluster prior to update                    | eks-rolling-update:original_max_capacity |
+| ASG_WAIT_FOR_DETACHMENT    | If True, waits for detachment to fully complete (draining connections etc) after terminating instance and detaching   | True                                     |
+| ASG_USE_TERMINATION_POLICY | Use ASG termination policy (instance terminate/detach handled by ASG according to configured termination policy)      | False                                    |
+| CLUSTER_HEALTH_WAIT        | Number of seconds to wait after ASG has been scaled up before checking health of the cluster                          | 90                                       |
+| CLUSTER_HEALTH_RETRY       | Number of attempts to validate the health of the cluster after ASG has been scaled                                    | 1                                        |
+| GLOBAL_MAX_RETRY           | Number of attempts of a health or termination check                                                                   | 12                                       |
+| GLOBAL_HEALTH_WAIT         | Number of seconds to wait before retrying a health check                                                              | 20                                       |
+| BETWEEN_NODES_WAIT         | Number of seconds to wait after removing a node before continuing on                                                  | 0                                        |
+| RUN_MODE                   | See Run Modes section below                                                                                           | 1                                        |
+| DRY_RUN                    | If True, only a query will be run to determine which worker nodes are outdated without running an update operation    | False                                    |
+| EXCLUDE_NODE_LABEL_KEYS    | List of space-delimited keys for node labels. Nodes with a label using one of these keys will be excluded from the node count when scaling the cluster. | "spotinst.io/node-lifecycle" |
+| EXTRA_DRAIN_ARGS           | Additional space-delimited args to supply to the `kubectl drain` function, e.g `--force=true`. See `kubectl drain -h` | ""                                       |
+| MAX_ALLOWABLE_NODE_AGE     | The max age each node allowed to be. This works with `RUN_MODE` 4 as node rolling is updating based on age of node    | 6                                        |
+| INSTANCE_WAIT_FOR_STOPPING | Wait for terminated instances to be in `stopping` or `shutting-down` state instead of `terminated` or `stopped`       | False                                    |
 
 ## Run Modes
+
 There are a number of different values which can be set for the `RUN_MODE` environment variable.
 
 `1` is the default.

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ eks_rolling_update.py -c my-eks-cluster
 | EXCLUDE_NODE_LABEL_KEYS    | List of space-delimited keys for node labels. Nodes with a label using one of these keys will be excluded from the node count when scaling the cluster. | "spotinst.io/node-lifecycle" |
 | EXTRA_DRAIN_ARGS           | Additional space-delimited args to supply to the `kubectl drain` function, e.g `--force=true`. See `kubectl drain -h` | ""                                       |
 | MAX_ALLOWABLE_NODE_AGE     | The max age each node allowed to be. This works with `RUN_MODE` 4 as node rolling is updating based on age of node    | 6                                        |
-| INSTANCE_WAIT_FOR_STOPPING | Wait for terminated instances to be in `stopping` or `shutting-down` state instead of `terminated` or `stopped`       | False                                    |
+| INSTANCE_WAIT_FOR_STOPPING | Wait for terminated instances to be in `stopping` or `shutting-down` state as well as `terminated` or `stopped`       | False                                    |
 
 ## Run Modes
 

--- a/eksrollup/config.py
+++ b/eksrollup/config.py
@@ -18,6 +18,7 @@ app_config = {
     'ASG_ORIG_MAX_CAPACITY_TAG': os.getenv('ASG_ORIG_MAX_CAPACITY_TAG', 'eks-rolling-update:original_max_capacity'),
     'ASG_WAIT_FOR_DETACHMENT': str_to_bool(os.getenv('ASG_WAIT_FOR_DETACHMENT', True)),
     'ASG_USE_TERMINATION_POLICY': str_to_bool(os.getenv('ASG_USE_TERMINATION_POLICY', False)),
+    'INSTANCE_WAIT_FOR_STOPPING': str_to_bool(os.getenv('INSTANCE_WAIT_FOR_STOPPING', False)),
     'CLUSTER_HEALTH_WAIT': int(os.getenv('CLUSTER_HEALTH_WAIT', 90)),
     'CLUSTER_HEALTH_RETRY': int(os.getenv('CLUSTER_HEALTH_RETRY', 1)),
     'GLOBAL_MAX_RETRY': int(os.getenv('GLOBAL_MAX_RETRY', 12)),

--- a/eksrollup/lib/aws.py
+++ b/eksrollup/lib/aws.py
@@ -288,9 +288,11 @@ def instance_outdated_age(instance_id, days_fresh):
         return False
 
 
-def instance_terminated(instance_id, max_retry=app_config['GLOBAL_MAX_RETRY'], wait=app_config['GLOBAL_HEALTH_WAIT']):
+def instance_terminated(instance_id, max_retry=app_config['GLOBAL_MAX_RETRY'], wait=app_config['GLOBAL_HEALTH_WAIT'],
+                        wait_for_stopping=app_config['INSTANCE_WAIT_FOR_STOPPING']):
     """
     Checks that an ec2 instance is terminated or stopped given an InstanceID
+    Overridable to detect shutting-down or stopped states
     """
     retry_count = 1
     is_instance_terminated = False
@@ -302,13 +304,16 @@ def instance_terminated(instance_id, max_retry=app_config['GLOBAL_MAX_RETRY'], w
         )
         state = response['Reservations'][0]['Instances'][0]['State']
         stop_states = ['terminated', 'stopped']
-        if state['Name'] not in stop_states:
-            is_instance_terminated = False
-            logger.info('Instance {} is still running, checking again...'.format(instance_id))
-        else:
-            logger.info('Instance {} terminated!'.format(instance_id))
+        stopping_states = ['shutting-down', 'stopping']
+
+        if state['Name'] in stop_states or (wait_for_stopping and state['Name'] in stopping_states):
+            logger.info('Instance {} {}!'.format(instance_id, state['Name']))
             is_instance_terminated = True
             break
+        else:
+            is_instance_terminated = False
+            logger.info('Instance {} is {}, checking again...'.format(instance_id, state['Name']))
+
         time.sleep(wait)
     return is_instance_terminated
 

--- a/tests/fixtures/aws_response_shutting_down.json
+++ b/tests/fixtures/aws_response_shutting_down.json
@@ -1,0 +1,186 @@
+{
+    "Reservations": [
+        {
+            "Groups": [
+                {
+                    "GroupName": "string",
+                    "GroupId": "string"
+                }
+            ],
+            "Instances": [
+                {
+                    "AmiLaunchIndex": 123,
+                    "ImageId": "string",
+                    "InstanceId": "string",
+                    "InstanceType": "m5.large",
+                    "KernelId": "string",
+                    "KeyName": "string",
+                    "LaunchTime": "date",
+                    "Monitoring": {
+                        "State": "disabled"
+                    },
+                    "Placement": {
+                        "AvailabilityZone": "string",
+                        "Affinity": "string",
+                        "GroupName": "string",
+                        "PartitionNumber": 123,
+                        "HostId": "string",
+                        "Tenancy": "default",
+                        "SpreadDomain": "string"
+                    },
+                    "Platform": "Windows",
+                    "PrivateDnsName": "string",
+                    "PrivateIpAddress": "string",
+                    "ProductCodes": [
+                        {
+                            "ProductCodeId": "string",
+                            "ProductCodeType": "marketplace"
+                        }
+                    ],
+                    "PublicDnsName": "string",
+                    "PublicIpAddress": "string",
+                    "RamdiskId": "string",
+                    "State": {
+                        "Code": 123,
+                        "Name": "shutting-down"
+                    },
+                    "StateTransitionReason": "string",
+                    "SubnetId": "string",
+                    "VpcId": "string",
+                    "Architecture": "x86_64",
+                    "BlockDeviceMappings": [
+                        {
+                            "DeviceName": "string",
+                            "Ebs": {
+                                "AttachTime": "date",
+                                "DeleteOnTermination": "true",
+                                "Status": "attached",
+                                "VolumeId": "string"
+                            }
+                        }
+                    ],
+                    "ClientToken": "string",
+                    "EbsOptimized": "true",
+                    "EnaSupport": "true",
+                    "Hypervisor": "xen",
+                    "IamInstanceProfile": {
+                        "Arn": "string",
+                        "Id": "string"
+                    },
+                    "InstanceLifecycle": "scheduled",
+                    "ElasticGpuAssociations": [
+                        {
+                            "ElasticGpuId": "string",
+                            "ElasticGpuAssociationId": "string",
+                            "ElasticGpuAssociationState": "string",
+                            "ElasticGpuAssociationTime": "string"
+                        }
+                    ],
+                    "ElasticInferenceAcceleratorAssociations": [
+                        {
+                            "ElasticInferenceAcceleratorArn": "string",
+                            "ElasticInferenceAcceleratorAssociationId": "string",
+                            "ElasticInferenceAcceleratorAssociationState": "string",
+                            "ElasticInferenceAcceleratorAssociationTime": "date"
+                        }
+                    ],
+                    "NetworkInterfaces": [
+                        {
+                            "Association": {
+                                "IpOwnerId": "string",
+                                "PublicDnsName": "string",
+                                "PublicIp": "string"
+                            },
+                            "Attachment": {
+                                "AttachTime": "date",
+                                "AttachmentId": "string",
+                                "DeleteOnTermination": "true",
+                                "DeviceIndex": 123,
+                                "Status": "attached"
+                            },
+                            "Description": "string",
+                            "Groups": [
+                                {
+                                    "GroupName": "string",
+                                    "GroupId": "string"
+                                }
+                            ],
+                            "Ipv6Addresses": [
+                                {
+                                    "Ipv6Address": "string"
+                                }
+                            ],
+                            "MacAddress": "string",
+                            "NetworkInterfaceId": "string",
+                            "OwnerId": "string",
+                            "PrivateDnsName": "string",
+                            "PrivateIpAddress": "string",
+                            "PrivateIpAddresses": [
+                                {
+                                    "Association": {
+                                        "IpOwnerId": "string",
+                                        "PublicDnsName": "string",
+                                        "PublicIp": "string"
+                                    },
+                                    "Primary": "true",
+                                    "PrivateDnsName": "string",
+                                    "PrivateIpAddress": "string"
+                                }
+                            ],
+                            "SourceDestCheck": "true",
+                            "Status": "available",
+                            "SubnetId": "string",
+                            "VpcId": "string",
+                            "InterfaceType": "string"
+                        }
+                    ],
+                    "RootDeviceName": "string",
+                    "RootDeviceType": "ebs",
+                    "SecurityGroups": [
+                        {
+                            "GroupName": "string",
+                            "GroupId": "string"
+                        }
+                    ],
+                    "SourceDestCheck": "true",
+                    "SpotInstanceRequestId": "string",
+                    "SriovNetSupport": "string",
+                    "StateReason": {
+                        "Code": "string",
+                        "Message": "string"
+                    },
+                    "Tags": [
+                        {
+                            "Key": "string",
+                            "Value": "string"
+                        }
+                    ],
+                    "VirtualizationType": "hvm",
+                    "CpuOptions": {
+                        "CoreCount": 123,
+                        "ThreadsPerCore": 123
+                    },
+                    "CapacityReservationId": "string",
+                    "CapacityReservationSpecification": {
+                        "CapacityReservationPreference": "none",
+                        "CapacityReservationTarget": {
+                            "CapacityReservationId": "string"
+                        }
+                    },
+                    "HibernationOptions": {
+                        "Configured": "true"
+                    },
+                    "Licenses": [
+                        {
+                            "LicenseConfigurationArn": "string"
+                        }
+                    ]
+                }
+            ],
+            "OwnerId": "string",
+            "RequesterId": "string",
+            "ReservationId": "string"
+        }
+    ],
+    "NextToken": "string"
+}

--- a/tests/test_aws.py
+++ b/tests/test_aws.py
@@ -52,6 +52,9 @@ class TestAWS(unittest.TestCase):
         with open(f"{current_dir}/fixtures/aws_response_terminated.json", "r") as file:
             self.aws_response_mock_terminated = json.load(file)
 
+        with open(f"{current_dir}/fixtures/aws_response_shutting_down.json", "r") as file:
+            self.aws_response_mock_shutting_down = json.load(file)
+
     def test_get_asg_tag(self):
         tags = [
             {
@@ -138,6 +141,11 @@ class TestAWS(unittest.TestCase):
         with patch('eksrollup.lib.aws.ec2_client.describe_instances') as describe_instances_mock:
             describe_instances_mock.return_value = self.aws_response_mock_terminated
             self.assertTrue(instance_terminated(self.instance_id, 2, 1))
+
+    def test_instance_shutting_down(self):
+        with patch('eksrollup.lib.aws.ec2_client.describe_instances') as describe_instances_mock:
+            describe_instances_mock.return_value = self.aws_response_mock_shutting_down
+            self.assertTrue(instance_terminated(self.instance_id, 2, 1, True))
 
     def test_instance_terminated_fail(self):
         self.assertFalse(instance_terminated(self.instance_id, 2, 1))


### PR DESCRIPTION
Hi 👋 

Firstly, this is a great tool! Virtual 🍻  from me!

This PR adds the ability to override the default behaviour when checking that an instance is terminated.

It adds the env variable: `INSTANCE_WAIT_FOR_STOPPING` which will also check for "stopping" states (`shutting-down`, `stopping`) which will speed up a run considerably in the trust that AWS really will terminate the instance eventually.

Any feedback or improvements would be appreciated :) 

Thanks!