### PR TITLE
Fix broken build in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ FROM python:3-alpine3.10
 COPY --from=builder /aws-iam-authenticator /kubectl /usr/local/bin/
 COPY --from=builder /dist/*.whl /tmp
 
-RUN apk add --no-cache bash
+RUN apk add --no-cache bash gcc musl-dev
 RUN pip3 install --no-cache-dir \
         awscli \
         /tmp/*.whl && \


### PR DESCRIPTION
Currently `make docker-dist version=1.0.DEV` fails with the following error due to missing `gcc` in the alpine image.
This PR adds `gcc` to fix the build.

```
  Building wheel for multidict (PEP 517): started
  Building wheel for multidict (PEP 517): finished with status 'error'
  ERROR: Command errored out with exit status 1:
   command: /usr/local/bin/python /usr/local/lib/python3.8/site-packages/pip/_vendor/pep517/_in_process.py build_wheel /tmp/tmpg_01hlzx
       cwd: /tmp/pip-install-041nro4c/multidict
  Complete output (43 lines):
  **********************
  * Accellerated build *
  **********************
  running bdist_wheel
  running build
  running build_py
  creating build
  creating build/lib.linux-x86_64-3.8
  creating build/lib.linux-x86_64-3.8/multidict
  copying multidict/_multidict_py.py -> build/lib.linux-x86_64-3.8/multidict
  copying multidict/_abc.py -> build/lib.linux-x86_64-3.8/multidict
  copying multidict/_multidict_base.py -> build/lib.linux-x86_64-3.8/multidict
  copying multidict/_compat.py -> build/lib.linux-x86_64-3.8/multidict
  copying multidict/__init__.py -> build/lib.linux-x86_64-3.8/multidict
  running egg_info
  writing multidict.egg-info/PKG-INFO
  writing dependency_links to multidict.egg-info/dependency_links.txt
  writing top-level names to multidict.egg-info/top_level.txt
  reading manifest file 'multidict.egg-info/SOURCES.txt'
  reading manifest template 'MANIFEST.in'
  warning: no previously-included files matching '*.pyc' found anywhere in distribution
  warning: no previously-included files found matching 'multidict/_multidict.html'
  warning: no previously-included files found matching 'multidict/*.so'
  warning: no previously-included files found matching 'multidict/*.pyd'
  warning: no previously-included files found matching 'multidict/*.pyd'
  no previously-included directories found matching 'docs/_build'
  writing manifest file 'multidict.egg-info/SOURCES.txt'
  copying multidict/__init__.pyi -> build/lib.linux-x86_64-3.8/multidict
  copying multidict/_multidict.c -> build/lib.linux-x86_64-3.8/multidict
  copying multidict/py.typed -> build/lib.linux-x86_64-3.8/multidict
  creating build/lib.linux-x86_64-3.8/multidict/_multilib
  copying multidict/_multilib/defs.h -> build/lib.linux-x86_64-3.8/multidict/_multilib
  copying multidict/_multilib/dict.h -> build/lib.linux-x86_64-3.8/multidict/_multilib
  copying multidict/_multilib/istr.h -> build/lib.linux-x86_64-3.8/multidict/_multilib
  copying multidict/_multilib/iter.h -> build/lib.linux-x86_64-3.8/multidict/_multilib
  copying multidict/_multilib/pair_list.h -> build/lib.linux-x86_64-3.8/multidict/_multilib
  copying multidict/_multilib/views.h -> build/lib.linux-x86_64-3.8/multidict/_multilib
  running build_ext
  building 'multidict._multidict' extension
  creating build/temp.linux-x86_64-3.8
  creating build/temp.linux-x86_64-3.8/multidict
  gcc -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -DTHREAD_STACK_SIZE=0x100000 -fPIC -I/usr/local/include/python3.8 -c multidict/_multidict.c -o build/temp.linux-x86_64-3.8/multidict/_multidict.o -O2 -std=c99 -Wall -Wsign-compare -Wconversion -fno-strict-aliasing -pedantic
  error: command 'gcc' failed with exit status 1
  ----------------------------------------
  ERROR: Failed building wheel for multidict
  Building wheel for yarl (PEP 517): started
  Building wheel for yarl (PEP 517): finished with status 'error'
  ERROR: Command errored out with exit status 1:
   command: /usr/local/bin/python /usr/local/lib/python3.8/site-packages/pip/_vendor/pep517/_in_process.py build_wheel /tmp/tmp98_wlnff
       cwd: /tmp/pip-install-041nro4c/yarl
  Complete output (38 lines):
  **********************
  * Accellerated build *
  **********************
  running bdist_wheel
  running build
  running build_py
  creating build
  creating build/lib.linux-x86_64-3.8
  creating build/lib.linux-x86_64-3.8/yarl
  copying yarl/_url.py -> build/lib.linux-x86_64-3.8/yarl
  copying yarl/_quoting.py -> build/lib.linux-x86_64-3.8/yarl
  copying yarl/_quoting_py.py -> build/lib.linux-x86_64-3.8/yarl
  copying yarl/__init__.py -> build/lib.linux-x86_64-3.8/yarl
  running egg_info
  writing yarl.egg-info/PKG-INFO
  writing dependency_links to yarl.egg-info/dependency_links.txt
  writing requirements to yarl.egg-info/requires.txt
  writing top-level names to yarl.egg-info/top_level.txt
  reading manifest file 'yarl.egg-info/SOURCES.txt'
  reading manifest template 'MANIFEST.in'
  warning: no previously-included files matching '*.pyc' found anywhere in distribution
  warning: no previously-included files matching '*.cache' found anywhere in distribution
  warning: no previously-included files found matching 'yarl/*.html'
  warning: no previously-included files found matching 'yarl/*.so'
  warning: no previously-included files found matching 'yarl/*.pyd'
  no previously-included directories found matching 'docs/_build'
  writing manifest file 'yarl.egg-info/SOURCES.txt'
  copying yarl/__init__.pyi -> build/lib.linux-x86_64-3.8/yarl
  copying yarl/_quoting_c.c -> build/lib.linux-x86_64-3.8/yarl
  copying yarl/_quoting_c.pyi -> build/lib.linux-x86_64-3.8/yarl
  copying yarl/_quoting_c.pyx -> build/lib.linux-x86_64-3.8/yarl
  copying yarl/py.typed -> build/lib.linux-x86_64-3.8/yarl
  running build_ext
  building 'yarl._quoting_c' extension
  creating build/temp.linux-x86_64-3.8
  creating build/temp.linux-x86_64-3.8/yarl
  gcc -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -DTHREAD_STACK_SIZE=0x100000 -fPIC -I/usr/local/include/python3.8 -c yarl/_quoting_c.c -o build/temp.linux-x86_64-3.8/yarl/_quoting_c.o
  error: command 'gcc' failed with exit status 1
  ----------------------------------------
  ERROR: Failed building wheel for yarl
Successfully built PyYAML
Failed to build multidict yarl
ERROR: Could not build wheels for multidict, yarl which use PEP 517 and cannot be installed directly
WARNING: You are using pip version 20.1.1; however, version 20.2.3 is available.
You should consider upgrading via the '/usr/local/bin/python -m pip install --upgrade pip' command.
The command '/bin/sh -c pip3 install --no-cache-dir         awscli         /tmp/*.whl &&         rm -rf /tmp/* &&   AWS_DEFAULT_REGION=us-east-1 eks_rolling_update.py -h' returned a non-zero code: 1
make: *** [Makefile:67: docker-dist] Error 1
```