### PR TITLE
Feature to specify selective AutoScaling Groups for rolling update

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ eks_rolling_update.py -c my-eks-cluster
 | EXCLUDE_NODE_LABEL_KEYS   | List of space-delimited keys for node labels. Nodes with a label using one of these keys will be excluded from the node count when scaling the cluster. | "spotinst.io/node-lifecycle" |
 | EXTRA_DRAIN_ARGS          | Additional space-delimited args to supply to the `kubectl drain` function, e.g `--force=true`. See `kubectl drain -h` | ""                                       |
 | MAX_ALLOWABLE_NODE_AGE    | The max age each node allowed to be. This works with `RUN_MODE` 4 as node rolling is updating based on age of node.      | 6                                          |
+| ASG_NAMES                 | List of space-delimited ASG names. Out of ASGs attached to the cluster, only these will be processed for rolling update. If this is left empty all ASGs of the cluster will be processed. | "" |
 
 ## Run Modes
 There are a number of different values which can be set for the `RUN_MODE` environment variable.

--- a/README.md
+++ b/README.md
@@ -123,7 +123,6 @@ eks_rolling_update.py -c my-eks-cluster
 | EXCLUDE_NODE_LABEL_KEYS   | List of space-delimited keys for node labels. Nodes with a label using one of these keys will be excluded from the node count when scaling the cluster. | "spotinst.io/node-lifecycle" |
 | EXTRA_DRAIN_ARGS          | Additional space-delimited args to supply to the `kubectl drain` function, e.g `--force=true`. See `kubectl drain -h` | ""                                       |
 | MAX_ALLOWABLE_NODE_AGE    | The max age each node allowed to be. This works with `RUN_MODE` 4 as node rolling is updating based on age of node.      | 6                                          |
-| ASG_NAMES                 | List of space-delimited ASG names. Out of ASGs attached to the cluster, only these will be processed for rolling update. If this is left empty all ASGs of the cluster will be processed. | "" |
 
 ## Run Modes
 There are a number of different values which can be set for the `RUN_MODE` environment variable.

--- a/eksrollup/config.py
+++ b/eksrollup/config.py
@@ -28,6 +28,5 @@ app_config = {
     'EXCLUDE_NODE_LABEL_KEYS': os.getenv('EXCLUDE_NODE_LABEL_KEYS', 'spotinst.io/node-lifecycle').split(),
     'EXTRA_DRAIN_ARGS': os.getenv('EXTRA_DRAIN_ARGS', '').split(),
     'MAX_ALLOWABLE_NODE_AGE': int(os.getenv('MAX_ALLOWABLE_NODE_AGE', 6)),
-    'TAINT_NODES': str_to_bool(os.getenv('TAINT_NODES', False)),
-    'ASG_NAMES': os.getenv('ASG_NAMES', '').split()
+    'TAINT_NODES': str_to_bool(os.getenv('TAINT_NODES', False))
 }

--- a/eksrollup/config.py
+++ b/eksrollup/config.py
@@ -28,5 +28,6 @@ app_config = {
     'EXCLUDE_NODE_LABEL_KEYS': os.getenv('EXCLUDE_NODE_LABEL_KEYS', 'spotinst.io/node-lifecycle').split(),
     'EXTRA_DRAIN_ARGS': os.getenv('EXTRA_DRAIN_ARGS', '').split(),
     'MAX_ALLOWABLE_NODE_AGE': int(os.getenv('MAX_ALLOWABLE_NODE_AGE', 6)),
-    'TAINT_NODES': str_to_bool(os.getenv('TAINT_NODES', False))
+    'TAINT_NODES': str_to_bool(os.getenv('TAINT_NODES', False)),
+    'ASG_NAMES': os.getenv('ASG_NAMES', '').split()
 }

--- a/eksrollup/lib/aws.py
+++ b/eksrollup/lib/aws.py
@@ -21,13 +21,6 @@ def get_asgs(cluster_tag):
     asg_query = "AutoScalingGroups[] | [?contains(Tags[?Key==`kubernetes.io/cluster/{}`].Value, `owned`)]".format(cluster_tag)
     # filter for only asgs with kube cluster tags
     filtered_asgs = page_iterator.search(asg_query)
-    if app_config['ASG_NAMES']:
-        # select only asgs provided in app_config['ASG_NAMES']
-        specific_asgs = []
-        for asg in filtered_asgs:
-            if asg['AutoScalingGroupName'] in app_config['ASG_NAMES']:
-                specific_asgs.append(asg)
-        filtered_asgs = specific_asgs
     return filtered_asgs
 
 

--- a/eksrollup/lib/aws.py
+++ b/eksrollup/lib/aws.py
@@ -21,6 +21,13 @@ def get_asgs(cluster_tag):
     asg_query = "AutoScalingGroups[] | [?contains(Tags[?Key==`kubernetes.io/cluster/{}`].Value, `owned`)]".format(cluster_tag)
     # filter for only asgs with kube cluster tags
     filtered_asgs = page_iterator.search(asg_query)
+    if app_config['ASG_NAMES']:
+        # select only asgs provided in app_config['ASG_NAMES']
+        specific_asgs = []
+        for asg in filtered_asgs:
+            if asg['AutoScalingGroupName'] in app_config['ASG_NAMES']:
+                specific_asgs.append(asg)
+        filtered_asgs = specific_asgs
     return filtered_asgs
 
 


### PR DESCRIPTION
We have a usecase where we want to apply rolling update to only some of the ASGs that run critical applications, and the remaining ones could be updated separately in a different time window.

Currently there is no option to specify this from the tool. I have added the functionality in this PR in which there is environment variable "ASG_NAMES" which can be given list of space-delimited ASG names. Only these provided ASGs will be processed for rolling update out of the ASGs attached to the cluster (i.e. those having the tag kubernetes.io/cluster/<cluster_tag> = owned). If "ASG_NAMES" is left empty, all cluster ASGs will be processed.

Please review this PR, and thanks for tool this works pretty well.