### PR TITLE
Fix bug with ASG scale up logic

### DIFF
--- a/eksrollup/cli.py
+++ b/eksrollup/cli.py
@@ -112,18 +112,16 @@ def scale_up_asg(cluster_name, asg, count):
         old_desired_capacity = asg_old_desired_capacity
 
         while True:
-            asg_instance_count = count_all_cluster_instances(cluster_name, predictive=predictive)
-            if asg_instance_count != desired_capacity:
-                if batch_size:
-                    if current_capacity is None:
-                        current_capacity = old_desired_capacity
-                    else:
-                        old_desired_capacity = current_capacity
-                    current_capacity += batch_size
-                    if current_capacity >= desired_capacity:
-                        current_capacity = desired_capacity
+            if batch_size:
+                if current_capacity is None:
+                    current_capacity = old_desired_capacity
                 else:
+                    old_desired_capacity = current_capacity
+                current_capacity += batch_size
+                if current_capacity >= desired_capacity:
                     current_capacity = desired_capacity
+            else:
+                current_capacity = desired_capacity
 
             # only change the max size if the new capacity is bigger than current max
             if current_capacity > asg_old_max_size:


### PR DESCRIPTION
I've removed this if statement which I'm pretty sure is an error but it would be useful if you could review @caphrim007.

It prevented the script working on one of my clusters where the desired (doubled) capacity of my first ASG was 8 and the total number of nodes in the cluster was also 8. This is with batch_size not set.

Adding an extra
```
else:
  current_capacity = desired_capacity
```
To the end of `if asg_instance_count != desired_capacity:` would also work but I can't see any case in which this case is useful. The logic inside `if batch_size` seems to take care of every case anyway from what I can tell.

Here are the logs:
```
2020-10-16 13:35:52,307 INFO     Instance id i-08dd62642ff5520a6 launch template version of '17' does not match asg launch template version of '18'
2020-10-16 13:35:52,307 INFO     Found 2 outdated instances
2020-10-16 13:35:52,308 INFO     Setting the scale of ASG wr-dev-0-spot based on 4 outdated instances.
2020-10-16 13:35:52,308 INFO     Modifying asg wr-dev-0-spot autoscaling to resume ...
2020-10-16 13:35:52,582 INFO     No previous capacity value tags set on ASG; setting tags.
2020-10-16 13:35:52,582 INFO     Saving tag to asg key: eks-rolling-update:original_capacity, value : 4...
2020-10-16 13:35:52,798 INFO     Saving tag to asg key: eks-rolling-update:desired_capacity, value : 8...
2020-10-16 13:35:53,007 INFO     Saving tag to asg key: eks-rolling-update:original_max_capacity, value : 5...
2020-10-16 13:35:53,228 INFO     Describing autoscaling groups...
2020-10-16 13:35:53,635 INFO     Current asg instance count in cluster is: 8. K8s node count should match this number
2020-10-16 13:35:53,636 ERROR    '>' not supported between instances of 'NoneType' and 'int'
2020-10-16 13:35:53,636 ERROR    *** Rolling update of ASG has failed. Exiting ***
2020-10-16 13:35:53,636 ERROR    AWS Auto Scaling Group processes will need resuming manually
2020-10-16 13:35:53,636 ERROR    Kubernetes Cluster Autoscaler will need resuming manually
```

Thanks
Sam