### PR TITLE
Ensure k8s config compatibility with kubernetes==12 python client + support proxies

### DIFF
--- a/eksrollup/cli.py
+++ b/eksrollup/cli.py
@@ -180,7 +180,7 @@ def update_asgs(asgs, cluster_name):
                     else:
                         taint_node(node_name)
                 except Exception as exception:
-                    logger.error(f"Encountered an error when adding taint/ cordoning node {node_name}")
+                    logger.error(f"Encountered an error when adding taint/cordoning node {node_name}")
                     logger.error(exception)
                     exit(1)
 
@@ -205,7 +205,7 @@ def update_asgs(asgs, cluster_name):
                     else:
                         taint_node(node_name)
                 except Exception as exception:
-                    logger.error(f"Encountered an error when when adding taint/ cordoning node {node_name}")
+                    logger.error(f"Encountered an error when adding taint/cordoning node {node_name}")
                     logger.error(exception)
                     exit(1)
 

--- a/eksrollup/lib/k8s.py
+++ b/eksrollup/lib/k8s.py
@@ -1,5 +1,6 @@
 from kubernetes import client, config
 from kubernetes.client.rest import ApiException
+import os
 import subprocess
 import time
 import sys
@@ -15,6 +16,11 @@ def ensure_config_loaded():
             config.load_kube_config()
         except config.ConfigException:
             raise Exception("Could not configure kubernetes python client")
+
+    proxy_url = os.getenv('HTTPS_PROXY', os.getenv('HTTP_PROXY', None))
+    if proxy_url:
+        logger.info(f"Setting proxy: {proxy_url}")
+        client.Configuration._default.proxy = proxy_url
 
 
 def get_k8s_nodes(exclude_node_label_keys=app_config["EXCLUDE_NODE_LABEL_KEYS"]):

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -2,6 +2,4 @@ moto==1.3.13
 python-box~=3.4.0
 flake8~=3.7.7
 nose2~=0.9.1
-kubernetes~=10.0.1
-python-dotenv~=0.10.2
 twine

--- a/tests/fixtures/example-kube-config.yaml
+++ b/tests/fixtures/example-kube-config.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Config
+current-context: example-context
+clusters:
+  - cluster:
+      server: https://localhost:8080
+    name: local-cluster
+contexts:
+  - context:
+      cluster: local-cluster
+      namespace: default
+      user: user
+    name: example-context
+users:
+  - name: user
+    user:
+      username: user
+      password: password


### PR DESCRIPTION
This PR makes two changes related to the way the Kubernetes python client is configured:

1. Fixes behaviour with Kubernetes python client v12 (fixes #72)
2. Adds support for use behind TLS passthrough forward proxies via standard OS env vars, similar to `kubectl` (fixes #64)

###  Kubernetes Python client v12 compatibility

The Kubernetes python client v12 seems to have somehow changed the way the default configuration works; such that if you create a `Configuration()` object you don't get the default configuration by default.

See https://github.com/kubernetes-client/python/issues/1284 and https://github.com/kubernetes-client/python/commit/b4d11b02a3479e63957a729614a616002f13e9c4#diff-59aff6ce4d28aa662f8b411b9d0dfe4f3e949c32a5edaf8e08905b58e7a41ee3L69-R71

Since we don't actually try to customise the `ApiClient` or the `Configuration` at all, it seems we are better to let the client handle creating with defaults that we have previously loaded.

Previously the script would fail on Kubernetes Python Client v12
- at `modify_k8s_autoscaler` if enabled
- at cordon|taint nodes depending on your `TAINT_NODES` setting (after waiting for node counts to match)

Notable is that it would get past node count matching; probably because that code didn't construct a manual configuration.

e.g
```
2020-10-26 00:26:29,033 ERROR    Encountered an error when adding taint/ cordoning node ip-xx-yy-zz.ap-southeast-1.compute.internal
2020-10-26 00:26:29,033 ERROR    HTTPConnectionPool(host='localhost', port=80): Max retries exceeded with url: /api/v1/nodes/ip-xx-yy-zz.ap-southeast-1.compute.internal (Caused by NewConnectionError('<urllib3.connection.HTTPConnection object at 0x11281c828>: Failed to establish a new connection: [Errno 61] Connection refused'))
```
Changes tested with both Kubernetes client v10 and v12.

### HTTPS_PROXY/HTTP_PROXY support

Adds support for standard OS-level env vars to set the proxy on the default configuration loaded from either the in-cluster or standard kube config.

This will only work for TLS passthrough proxies; since the client validates the certificates. Tested with [mitmproxy](https://mitmproxy.org/) against a real cluster.