### PR TITLE
disable proxy for k8s only when configured.

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ eks_rolling_update.py -c my-eks-cluster
 | INSTANCE_WAIT_FOR_STOPPING | Wait for terminated instances to be in `stopping` or `shutting-down` state as well as `terminated` or `stopped`       | False                                    |
 | BATCH_SIZE                 | Instances to scale the ASG by at a time. When set to 0, batching is disabled.                                         | 0                                        |
 | ASG_NAMES                 | List of space-delimited ASG names. Out of ASGs attached to the cluster, only these will be processed for rolling update. If this is left empty all ASGs of the cluster will be processed. | "" |
+| K8S_PROXY_BYPASS          | If set to `true` then connectivity to kube cluster doesnt use `HTTP_PROXY` or `HTTPS_PROXY` environment variables but boto would still connect adhere to these environment variables. | "" |
 
 ## Run Modes
 

--- a/eksrollup/lib/k8s.py
+++ b/eksrollup/lib/k8s.py
@@ -18,7 +18,9 @@ def ensure_config_loaded():
             raise Exception("Could not configure kubernetes python client")
 
     proxy_url = os.getenv('HTTPS_PROXY', os.getenv('HTTP_PROXY', None))
-    if proxy_url:
+    no_k8s_proxy_pass = os.getenv('N0_K8S_PROXY_PASS')
+
+    if proxy_url and no_k8s_proxy_pass != "true":
         logger.info(f"Setting proxy: {proxy_url}")
         client.Configuration._default.proxy = proxy_url
 

--- a/eksrollup/lib/k8s.py
+++ b/eksrollup/lib/k8s.py
@@ -18,9 +18,9 @@ def ensure_config_loaded():
             raise Exception("Could not configure kubernetes python client")
 
     proxy_url = os.getenv('HTTPS_PROXY', os.getenv('HTTP_PROXY', None))
-    no_k8s_proxy_pass = os.getenv('N0_K8S_PROXY_PASS')
+    k8s_proxy_bypass = os.getenv('K8S_PROXY_BYPASS')
 
-    if proxy_url and no_k8s_proxy_pass != "true":
+    if proxy_url and k8s_proxy_bypass != "true":
         logger.info(f"Setting proxy: {proxy_url}")
         client.Configuration._default.proxy = proxy_url
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 boto3~=1.9.246
 kubernetes~=10.0.1
 python-dotenv~=0.10.2
+urllib3<1.26

--- a/tests/test_k8s.py
+++ b/tests/test_k8s.py
@@ -35,6 +35,12 @@ class TestK8S(unittest.TestCase):
             ensure_config_loaded()
             self.assertEqual('http://localhost:12345', ApiClient().configuration.proxy)
 
+    def test_ensure_config_loaded_proxy_not_set_when_no_k8s_set(self):
+        with patch.dict(os.environ, {'N0_K8S_PROXY_PASS': 'true', 'HTTP_PROXY': 'http://localhost:6789'}):
+            ensure_config_loaded()
+            self.assertNotEqual('http://localhost:6789', ApiClient().configuration.proxy)
+
+
     def test_k8s_node_count(self):
         with patch('eksrollup.lib.k8s.get_k8s_nodes') as get_k8s_nodes_mock:
             get_k8s_nodes_mock.return_value = self.k8s_response_mock['items']

--- a/tests/test_k8s.py
+++ b/tests/test_k8s.py
@@ -36,7 +36,7 @@ class TestK8S(unittest.TestCase):
             self.assertEqual('http://localhost:12345', ApiClient().configuration.proxy)
 
     def test_ensure_config_loaded_proxy_not_set_when_no_k8s_set(self):
-        with patch.dict(os.environ, {'N0_K8S_PROXY_PASS': 'true', 'HTTP_PROXY': 'http://localhost:6789'}):
+        with patch.dict(os.environ, {'K8S_PROXY_BYPASS': 'true', 'HTTP_PROXY': 'http://localhost:6789'}):
             ensure_config_loaded()
             self.assertNotEqual('http://localhost:6789', ApiClient().configuration.proxy)
 


### PR DESCRIPTION
This PR improves the proxy support in #73 to give some flexibility in when the proxy is used. In our case we have the following requirements:

1. Calls to AWS APIs must use `HTTP_PROXY` since we have no direct internet access in our VPCs 
2. Calls to k8s cluster must not go via `HTTP_PROXY`. 

In this case we must have `HTTP_PROXY` set but this causes the rolling update code to try and also go via `HTTP_PROXY`. `NO_PROXY` is configured to include the k8s cluster endpoint but isn't adhered to here. 

I wanted to adhere to `NO_PROXY` originally but I couldn't see a good way get `servers` value from kubernetes python client once it loaded config, to see if it matched something in `NO_PROXT`. I also didn't think it would be a good idea read kube config independently. 

For the above reasons I went with an additional environment variable `N0_K8S_PROXY_PASS`. 

I'm happy to change tactics here if you think there's a better way. 