### PR TITLE
feature to enforce draining of nodes when pods cannot be evicted

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,8 @@ eks_rolling_update.py -c my-eks-cluster
 | MAX_ALLOWABLE_NODE_AGE     | The max age each node allowed to be. This works with `RUN_MODE` 4 as node rolling is updating based on age of node    | 6                                        |
 | INSTANCE_WAIT_FOR_STOPPING | Wait for terminated instances to be in `stopping` or `shutting-down` state as well as `terminated` or `stopped`       | False                                    |
 | BATCH_SIZE                 | Instances to scale the ASG by at a time. When set to 0, batching is disabled.                                         | 0                                        |
-| ASG_NAMES                 | List of space-delimited ASG names. Out of ASGs attached to the cluster, only these will be processed for rolling update. If this is left empty all ASGs of the cluster will be processed. | "" |
+| ENFORCED_DRAINING          | If draining failed for a node due to corrupted podDisruptionBudgets or failing pods retry draining with `--disable-eviction=true` and `--force=true` for this node to prevent aborting the script. This is useful to get the rolling update done in development and testing environments and **should not be used in productive environments**. | False |
+| ASG_NAMES                  | List of space-delimited ASG names. Out of ASGs attached to the cluster, only these will be processed for rolling update. If this is left empty all ASGs of the cluster will be processed. | "" |
 
 ## Run Modes
 

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ eks_rolling_update.py -c my-eks-cluster
 | MAX_ALLOWABLE_NODE_AGE     | The max age each node allowed to be. This works with `RUN_MODE` 4 as node rolling is updating based on age of node    | 6                                        |
 | INSTANCE_WAIT_FOR_STOPPING | Wait for terminated instances to be in `stopping` or `shutting-down` state as well as `terminated` or `stopped`       | False                                    |
 | BATCH_SIZE                 | Instances to scale the ASG by at a time. When set to 0, batching is disabled.                                         | 0                                        |
-| ENFORCED_DRAINING          | If draining failed for a node due to corrupted podDisruptionBudgets or failing pods retry draining with `--disable-eviction=true` and `--force=true` for this node to prevent aborting the script. This is useful to get the rolling update done in development and testing environments and **should not be used in productive environments**. | False |
+| ENFORCED_DRAINING          | If draining failed for a node due to corrupted podDisruptionBudgets or failing pods retry draining with `--disable-eviction=true` and `--force=true` for this node to prevent aborting the script. This is useful to get the rolling update done in development and testing environments and **should not be used in productive environments** since this will bypass checking PodDisruptionBudgets | False |
 | ASG_NAMES                  | List of space-delimited ASG names. Out of ASGs attached to the cluster, only these will be processed for rolling update. If this is left empty all ASGs of the cluster will be processed. | "" |
 
 ## Run Modes

--- a/eksrollup/config.py
+++ b/eksrollup/config.py
@@ -31,5 +31,6 @@ app_config = {
     'MAX_ALLOWABLE_NODE_AGE': int(os.getenv('MAX_ALLOWABLE_NODE_AGE', 6)),
     'TAINT_NODES': str_to_bool(os.getenv('TAINT_NODES', False)),
     'BATCH_SIZE': int(os.getenv('BATCH_SIZE', 0)),
+    'ENFORCED_DRAINING': str_to_bool(os.getenv('ENFORCED_DRAINING', False)),
     'ASG_NAMES': os.getenv('ASG_NAMES', '').split()
 }


### PR DESCRIPTION
#### Problem
when running the script in a cluster containing misconfigured podDisruptionBudgets (e.g. minAvailable: 1 and only one replica running) or just containers which aren't running, the script fails while draining nodes. we were facing this behaviour in development and testing environments.

#### Solution
to be able to complete a rolling update in such clusters we've added an optional enforced_draining which retries draining a node after failing while evicting pods.
example execution output is attached:
[eks-rolling-update_enforced-draining.txt](https://github.com/hellofresh/eks-rolling-update/files/5634734/eks-rolling-update_enforced-draining.txt)