### PR TITLE
[WIP] Fixes #83: fix count all cluster instance returns wrong value

### DIFF
--- a/eksrollup/lib/aws.py
+++ b/eksrollup/lib/aws.py
@@ -8,10 +8,17 @@ from eksrollup.config import app_config
 client = boto3.client('autoscaling')
 ec2_client = boto3.client('ec2')
 
-
-def get_asgs(cluster_tag):
+def get_all_asgs(cluster_tag):
     """
     Queries AWS and returns all ASG's matching kubernetes.io/cluster/<cluster_tag> = owned
+    """
+    get_asgs(cluster_tag, [])
+
+
+def get_asgs(cluster_tag, asg_names = app_config['ASG_NAMES']):
+    """
+    Queries AWS and find ASG's matching kubernetes.io/cluster/<cluster_tag> = owned
+    If asg_names is not empty, returns only asgs that are inside that list, else return all above asgs
     """
     logger.info('Describing autoscaling groups...')
     paginator = client.get_paginator('describe_auto_scaling_groups')
@@ -21,11 +28,11 @@ def get_asgs(cluster_tag):
     asg_query = "AutoScalingGroups[] | [?contains(Tags[?Key==`kubernetes.io/cluster/{}`].Value, `owned`)]".format(cluster_tag)
     # filter for only asgs with kube cluster tags
     filtered_asgs = page_iterator.search(asg_query)
-    if app_config['ASG_NAMES']:
-        # select only asgs provided in app_config['ASG_NAMES']
+    if asg_names:
+        # select only asgs provided in asg_names
         specific_asgs = []
         for asg in filtered_asgs:
-            if asg['AutoScalingGroupName'] in app_config['ASG_NAMES']:
+            if asg['AutoScalingGroupName'] in asg_names:
                 specific_asgs.append(asg)
         filtered_asgs = specific_asgs
     return filtered_asgs
@@ -413,7 +420,7 @@ def count_all_cluster_instances(cluster_name, predictive=False):
     Returns the total number of ec2 instances in a k8s cluster
     """
     count = 0
-    asgs = get_asgs(cluster_name)
+    asgs = get_all_asgs(cluster_name)
     for asg in asgs:
         if predictive:
             count += asg['DesiredCapacity']


### PR DESCRIPTION
After #69 is merged, count_all_cluster_instances returned only instances
in filtered asg names list instead of all instances inside the cluster.

This commit attempts to fix that by changing count_all_cluster_instances
to its original behaviour.

There is a potential problem with this fix. Ideally if we want to roll asg A, 
we should only count instances in that group instead of counting all 
instances like this PR propose.But I can't find an easy way to do it yet.
At least this PR will allow eks_rolling_update works correctly when 
ASG_NAMES is set