### PR TITLE
Tidy configuration & improve readme readability

### DIFF
--- a/eksrollup/config.py
+++ b/eksrollup/config.py
@@ -18,7 +18,6 @@ app_config = {
     'ASG_DESIRED_STATE_TAG': os.getenv('ASG_DESIRED_STATE_TAG', 'eks-rolling-update:desired_capacity'),
     'ASG_ORIG_CAPACITY_TAG': os.getenv('ASG_ORIG_CAPACITY_TAG', 'eks-rolling-update:original_capacity'),
     'ASG_ORIG_MAX_CAPACITY_TAG': os.getenv('ASG_ORIG_MAX_CAPACITY_TAG', 'eks-rolling-update:original_max_capacity'),
-    'ASG_WAIT_FOR_DETACHMENT': str_to_bool(os.getenv('ASG_WAIT_FOR_DETACHMENT', True)),
     'ASG_USE_TERMINATION_POLICY': str_to_bool(os.getenv('ASG_USE_TERMINATION_POLICY', False)),
     'INSTANCE_WAIT_FOR_STOPPING': str_to_bool(os.getenv('INSTANCE_WAIT_FOR_STOPPING', False)),
     'CLUSTER_HEALTH_WAIT': int(os.getenv('CLUSTER_HEALTH_WAIT', 90)),

--- a/eksrollup/config.py
+++ b/eksrollup/config.py
@@ -14,6 +14,7 @@ app_config = {
     'K8S_AUTOSCALER_DEPLOYMENT': os.getenv('K8S_AUTOSCALER_DEPLOYMENT', 'cluster-autoscaler'),
     'K8S_AUTOSCALER_REPLICAS': int(os.getenv('K8S_AUTOSCALER_REPLICAS', 2)),
     'K8S_CONTEXT': os.getenv('K8S_CONTEXT', None),
+    'K8S_PROXY_BYPASS': str_to_bool(os.getenv('K8S_PROXY_BYPASS', False)),
     'ASG_DESIRED_STATE_TAG': os.getenv('ASG_DESIRED_STATE_TAG', 'eks-rolling-update:desired_capacity'),
     'ASG_ORIG_CAPACITY_TAG': os.getenv('ASG_ORIG_CAPACITY_TAG', 'eks-rolling-update:original_capacity'),
     'ASG_ORIG_MAX_CAPACITY_TAG': os.getenv('ASG_ORIG_MAX_CAPACITY_TAG', 'eks-rolling-update:original_max_capacity'),

--- a/eksrollup/lib/k8s.py
+++ b/eksrollup/lib/k8s.py
@@ -18,9 +18,7 @@ def ensure_config_loaded():
             raise Exception("Could not configure kubernetes python client")
 
     proxy_url = os.getenv('HTTPS_PROXY', os.getenv('HTTP_PROXY', None))
-    k8s_proxy_bypass = os.getenv('K8S_PROXY_BYPASS')
-
-    if proxy_url and k8s_proxy_bypass != "true":
+    if proxy_url and not app_config['K8S_PROXY_BYPASS']:
         logger.info(f"Setting proxy: {proxy_url}")
         client.Configuration._default.proxy = proxy_url
 

--- a/tests/test_k8s.py
+++ b/tests/test_k8s.py
@@ -35,8 +35,9 @@ class TestK8S(unittest.TestCase):
             ensure_config_loaded()
             self.assertEqual('http://localhost:12345', ApiClient().configuration.proxy)
 
+    @patch.dict("eksrollup.lib.k8s.app_config", {'K8S_PROXY_BYPASS': True})
     def test_ensure_config_loaded_proxy_not_set_when_no_k8s_set(self):
-        with patch.dict(os.environ, {'K8S_PROXY_BYPASS': 'true', 'HTTP_PROXY': 'http://localhost:6789'}):
+        with patch.dict(os.environ, {'HTTP_PROXY': 'http://localhost:6789'}):
             ensure_config_loaded()
             self.assertNotEqual('http://localhost:6789', ApiClient().configuration.proxy)
 


### PR DESCRIPTION
The # of env vars & complexity of configuration has grown quite a lot. Without consistent semantic prefixing of the env vars, or a structured config approach it's getting a bit difficult to understand the options we have when configuring the tool.

To try and improve this, this PR

- removes an unused config option
- ensures all custom tool env vars are defined within `config.py` and parsed off the env consistently (principle of least-surprise)
- adds the missing documentation for `TAINT_NODES=true`
- tweaks some of the wording for conciseness
- restructures the env vars to make them easier to understand and work with

Possibly easiest to review with the "rich diff" of the markdown.
