### PR TITLE
fix: handle missing launch templates

### DIFF
--- a/eksrollup/cli.py
+++ b/eksrollup/cli.py
@@ -268,7 +268,7 @@ def main(args=None):
     filtered_asgs = get_asgs(args.cluster_name)
     run_mode = app_config['RUN_MODE']
     # perform a dry run on mode 4 for older nodes
-    if args.plan or app_config['DRY_RUN'] and (run_mode == 4):
+    if (args.plan or app_config['DRY_RUN']) and (run_mode == 4):
         plan_asgs_older_nodes(filtered_asgs)
     # perform a dry run on main mode
     elif args.plan or app_config['DRY_RUN']:

--- a/eksrollup/lib/aws.py
+++ b/eksrollup/lib/aws.py
@@ -247,8 +247,12 @@ def instance_outdated_launchtemplate(instance_obj, asg_lt_name, asg_lt_version):
     describe_launch_templates boto3 method (wrapped in get_launch_template).
     """
     instance_id = instance_obj['InstanceId']
-    lt_name = instance_obj['LaunchTemplate']['LaunchTemplateName']
-    lt_version = int(instance_obj['LaunchTemplate']['Version'])
+    try:
+        lt_name = instance_obj['LaunchTemplate']['LaunchTemplateName']
+        lt_version = int(instance_obj['LaunchTemplate']['Version'])
+    except KeyError:
+        logger.info("Instance id {} does not match asg launch template of '{}'".format(instance_id, asg_lt_name))
+        return True
 
     if lt_name != asg_lt_name:
         logger.info("Instance id {} launch template of '{}' does not match asg launch template of '{}'".format(instance_id, lt_name, asg_lt_name))

--- a/eksrollup/lib/aws.py
+++ b/eksrollup/lib/aws.py
@@ -251,7 +251,7 @@ def instance_outdated_launchtemplate(instance_obj, asg_lt_name, asg_lt_version):
         lt_name = instance_obj['LaunchTemplate']['LaunchTemplateName']
         lt_version = int(instance_obj['LaunchTemplate']['Version'])
     except KeyError:
-        logger.info("Instance id {} does not match asg launch template of '{}'".format(instance_id, asg_lt_name))
+        logger.info("Instance id {} missing launch template does not match asg launch template of '{}'".format(instance_id, asg_lt_name))
         return True
 
     if lt_name != asg_lt_name:

--- a/tests/test_aws_launchtemplate.py
+++ b/tests/test_aws_launchtemplate.py
@@ -20,6 +20,9 @@ class TestAWS(unittest.TestCase):
             self.aws_response_mock_latest = json.load(file)
         with open(f"{current_dir}/fixtures/get_launch_template.json", "r") as file:
             self.mock_get_launch_template = json.load(file)
+        with open(f"{current_dir}/fixtures/aws_response.json", "r") as file:
+            self.aws_response_mock_no_launch_template = json.load(file)
+
 
     def test_is_instance_outdated(self):
         response = self.aws_response_mock
@@ -77,3 +80,13 @@ class TestAWS(unittest.TestCase):
             with patch('eksrollup.lib.aws.get_launch_template') as get_launch_template_mock:
                 get_launch_template_mock.return_value = self.mock_get_launch_template
                 self.assertTrue(instance_outdated_launchtemplate(instances[2], 'mock-lt-01', '$Latest'))
+
+    def test_is_instance_outdated_fail_no_launch_template(self):
+        response = self.aws_response_mock_no_launch_template
+        asgs = response['AutoScalingGroups']
+        for asg in asgs:
+            instances = asg['Instances']
+            with patch('eksrollup.lib.aws.get_launch_template') as get_launch_template_mock:
+                get_launch_template_mock.return_value = self.mock_get_launch_template
+                self.assertTrue(instance_outdated_launchtemplate(instances[0], 'mock-lt-01', '$Latest'))
+


### PR DESCRIPTION
We recently moved from Launch Configurations to Launch Templates and had instances without LaunchTemplate configuration in an ASG that used LaunchTemplates. This resulted in an error when trying to compare launch template versions on those instances.

This PR fixes that and also fixes up a small bug in plan output.
