### PR TITLE
feat: WIP: allow user to over-scale a buffer of instances in an ASG

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ eks_rolling_update.py -c my-eks-cluster
 | ASG_ORIG_CAPACITY_TAG      | Temporary tag which will be saved to the ASG to store the state of the EKS cluster prior to update                          | eks-rolling-update:original_capacity     |
 | ASG_ORIG_MAX_CAPACITY_TAG  | Temporary tag which will be saved to the ASG to store the state of the EKS cluster prior to update                          | eks-rolling-update:original_max_capacity |
 | ASG_NAMES                  | List of space-delimited ASG names. Out of ASGs attached to the cluster, only these will be processed for rolling update. If this is left empty all ASGs of the cluster will be processed. | "" |
+| ASG_BUFFER_INSTANCES       | # of instances to overprovision the ASG by to allow workloads to scale out and soft affinity/anti-affinity rules to be respected | 0                                        | 
 | BATCH_SIZE                 | # of instances to scale the ASG by at a time. When set to 0, batching is disabled. See [Batching](#batching) section        | 0                                        |
 | MAX_ALLOWABLE_NODE_AGE     | The max age each node allowed to be. This works with `RUN_MODE` 4 as node rolling is updating based on age of node          | 6                                        |
 | EXCLUDE_NODE_LABEL_KEYS    | List of space-delimited keys for node labels. Nodes with a label using one of these keys will be excluded from the node count when scaling the cluster. | spotinst.io/node-lifecycle |

--- a/eksrollup/cli.py
+++ b/eksrollup/cli.py
@@ -56,7 +56,7 @@ def validate_cluster_health(asg_name, new_desired_asg_capacity, cluster_name, pr
 def scale_up_asg(cluster_name, asg, count):
     asg_old_max_size = asg['MaxSize']
     asg_old_desired_capacity = asg['DesiredCapacity']
-    desired_capacity = asg_old_desired_capacity + count
+    desired_capacity = asg_old_desired_capacity + count + app_config['ASG_BUFFER_INSTANCES']
     asg_tags = asg['Tags']
     asg_name = asg['AutoScalingGroupName']
     current_capacity = None

--- a/eksrollup/cli.py
+++ b/eksrollup/cli.py
@@ -55,7 +55,7 @@ def validate_cluster_health(asg_name, new_desired_asg_capacity, cluster_name, pr
 
 def scale_up_asg(cluster_name, asg, count):
     asg_old_max_size = asg['MaxSize']
-    asg_old_desired_capacity = asg['DesiredCapacity']
+    asg_old_desired_capacity = asg['DesiredCapacity'] + app_config['ASG_BUFFER_INSTANCES']
     desired_capacity = asg_old_desired_capacity + count + app_config['ASG_BUFFER_INSTANCES']
     asg_tags = asg['Tags']
     asg_name = asg['AutoScalingGroupName']

--- a/eksrollup/config.py
+++ b/eksrollup/config.py
@@ -15,6 +15,7 @@ app_config = {
     'K8S_AUTOSCALER_REPLICAS': int(os.getenv('K8S_AUTOSCALER_REPLICAS', 2)),
     'K8S_CONTEXT': os.getenv('K8S_CONTEXT', None),
     'K8S_PROXY_BYPASS': str_to_bool(os.getenv('K8S_PROXY_BYPASS', False)),
+    'ASG_BUFFER_INSTANCES': os.getenv('ASG_BUFFER_INSTANCES', 0),
     'ASG_DESIRED_STATE_TAG': os.getenv('ASG_DESIRED_STATE_TAG', 'eks-rolling-update:desired_capacity'),
     'ASG_ORIG_CAPACITY_TAG': os.getenv('ASG_ORIG_CAPACITY_TAG', 'eks-rolling-update:original_capacity'),
     'ASG_ORIG_MAX_CAPACITY_TAG': os.getenv('ASG_ORIG_MAX_CAPACITY_TAG', 'eks-rolling-update:original_max_capacity'),

--- a/eksrollup/config.py
+++ b/eksrollup/config.py
@@ -15,7 +15,7 @@ app_config = {
     'K8S_AUTOSCALER_REPLICAS': int(os.getenv('K8S_AUTOSCALER_REPLICAS', 2)),
     'K8S_CONTEXT': os.getenv('K8S_CONTEXT', None),
     'K8S_PROXY_BYPASS': str_to_bool(os.getenv('K8S_PROXY_BYPASS', False)),
-    'ASG_BUFFER_INSTANCES': os.getenv('ASG_BUFFER_INSTANCES', 0),
+    'ASG_BUFFER_INSTANCES': int(os.getenv('ASG_BUFFER_INSTANCES', 0)),
     'ASG_DESIRED_STATE_TAG': os.getenv('ASG_DESIRED_STATE_TAG', 'eks-rolling-update:desired_capacity'),
     'ASG_ORIG_CAPACITY_TAG': os.getenv('ASG_ORIG_CAPACITY_TAG', 'eks-rolling-update:original_capacity'),
     'ASG_ORIG_MAX_CAPACITY_TAG': os.getenv('ASG_ORIG_MAX_CAPACITY_TAG', 'eks-rolling-update:original_max_capacity'),


### PR DESCRIPTION
Hello 👋 - A few weeks ago I opened #96 but promptly closed it as I could have solved the problem with a different tool. After looking back at this, I think it'd be simpler if solved in `eks-rolling-update` directly.

This PR adds a new env variable: `ASG_BUFFER_INSTANCES` which allows an arbitrary number to be given to `eks_rolling_update.py` and will cause each ASG to be over-scaled by that number.

### But why?
The past few rolling upgrades I've done have resulted in some things like workloads with PV/PVC getting stuck in pending as other pods had started, scaleout of HPAs causing pods to get stuck in pending, deployments during rollout causing issues...

Since I've been pre-scaling each ASG by a few instances it hasn't been an issue and `cluster-autoscaler` takes care of scaling in unused compute after rollout.

As always, open to any feedback or ideas 😸 

Thanks for an awesome tool! 