### PR TITLE
GH Fix Version Variable

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -29,7 +29,7 @@ jobs:
       env:
         VERSION: 1.1
       run: |
-        make before-dist version=${{VERSION}}.${{ github.run_number }}
+        make before-dist version=$VERSION.${{ github.run_number }}
 
     - name: Upload to PyPi
       run: |


### PR DESCRIPTION
Fixes gh actions error
>The workflow is not valid. .github/workflows/deploy.yaml (Line: 31, Col: 12): Unrecognized named-value: 'VERSION'. Located at position 1 within expression: VERSION
