### PR TITLE
Adding run mode 5 (which scales up the ASGs by one instance)

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ There are a number of different values which can be set for the `RUN_MODE` envir
 | 2             | Scale up and cordon/taint the outdated nodes of all ASGs all at once at the beginning of the run.                     |
 | 3             | Cordon/taint the outdated nodes of all ASGs at the beginning of the run but scale each ASG one-by-one.                |
 | 4             | Roll EKS nodes based on age instead of launch config (works with `MAX_ALLOWABLE_NODE_AGE` with default 6 days value). |
+| 5             | Scale up nodes by one and cordon/taint the outdated nodes of each ASG one-by-one, just before we drain them.          |
 
 Each of them have different advantages and disadvantages.
 * Scaling up all ASGs at once may cause AWS EC2 instance limits to be exceeded

--- a/eksrollup/lib/aws.py
+++ b/eksrollup/lib/aws.py
@@ -48,7 +48,7 @@ def get_launch_template(lt_name):
     return response['LaunchTemplates'][0]
 
 
-def terminate_instance_in_asg(instance_id):
+def terminate_instance_in_asg(instance_id, should_decrement_desired_capacity):
     """
     Terminates EC2 instance given an instance ID
     """
@@ -57,7 +57,7 @@ def terminate_instance_in_asg(instance_id):
         try:
             response = client.terminate_instance_in_auto_scaling_group(
                 InstanceId=instance_id,
-                ShouldDecrementDesiredCapacity=True
+                ShouldDecrementDesiredCapacity=should_decrement_desired_capacity
             )
             if response['ResponseMetadata']['HTTPStatusCode'] == requests.codes.ok:
                 logger.info('Termination signal for instance is successfully sent.')


### PR DESCRIPTION
In cases where the number of instances that can be added to the cluster are constrained, it may not always be possible to scale up the ASGs by the number of outdated instances (especially if all of the nodes in the cluster are outdated). To handle this problem, this PR adds a new mode which scales up the ASGs by one, if the ASG has outdated instances.