### PR TITLE
update boto3 for python 3.10 compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-boto3~=1.9.246
+boto3~=1.21.41
 kubernetes~=10.0.1
 python-dotenv~=0.10.2
 urllib3<1.26


### PR DESCRIPTION
This was on an old version of boto3 which was not compatible with python 3.10 due to removal of deprecated `collections.abc` aliases, updating boto3 in requirements.txt fixed this issue

> Remove deprecated aliases to Collections Abstract Base Classes from the collections module. (Contributed by Victor Stinner in bpo-37324.)