### PR TITLE
adding option to add extra nodes to each asg

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ eks_rolling_update.py -c my-eks-cluster
 | ASG_DESIRED_STATE_TAG      | Temporary tag which will be saved to the ASG to store the state of the EKS cluster prior to update                          | eks-rolling-update:desired_capacity      |
 | ASG_ORIG_CAPACITY_TAG      | Temporary tag which will be saved to the ASG to store the state of the EKS cluster prior to update                          | eks-rolling-update:original_capacity     |
 | ASG_ORIG_MAX_CAPACITY_TAG  | Temporary tag which will be saved to the ASG to store the state of the EKS cluster prior to update                          | eks-rolling-update:original_max_capacity |
+| ASG_OVERSCALE_INSTANCES    | # of Nodes to add to each ASG to account for new pods created in the EKS cluster while cluster autoscaler is disabled       | 0                                        |
 | ASG_NAMES                  | List of space-delimited ASG names. Out of ASGs attached to the cluster, only these will be processed for rolling update. If this is left empty all ASGs of the cluster will be processed. | "" |
 | BATCH_SIZE                 | # of instances to scale the ASG by at a time. When set to 0, batching is disabled. See [Batching](#batching) section        | 0                                        |
 | MAX_ALLOWABLE_NODE_AGE     | The max age each node allowed to be. This works with `RUN_MODE` 4 as node rolling is updating based on age of node          | 6                                        |

--- a/eksrollup/cli.py
+++ b/eksrollup/cli.py
@@ -56,7 +56,7 @@ def validate_cluster_health(asg_name, new_desired_asg_capacity, cluster_name, pr
 def scale_up_asg(cluster_name, asg, count):
     asg_old_max_size = asg['MaxSize']
     asg_old_desired_capacity = asg['DesiredCapacity']
-    desired_capacity = asg_old_desired_capacity + count
+    desired_capacity = asg_old_desired_capacity + count + app_config['ASG_OVERSCALE_INSTANCES']
     asg_tags = asg['Tags']
     asg_name = asg['AutoScalingGroupName']
     current_capacity = None

--- a/eksrollup/config.py
+++ b/eksrollup/config.py
@@ -19,6 +19,7 @@ app_config = {
     'ASG_ORIG_CAPACITY_TAG': os.getenv('ASG_ORIG_CAPACITY_TAG', 'eks-rolling-update:original_capacity'),
     'ASG_ORIG_MAX_CAPACITY_TAG': os.getenv('ASG_ORIG_MAX_CAPACITY_TAG', 'eks-rolling-update:original_max_capacity'),
     'ASG_USE_TERMINATION_POLICY': str_to_bool(os.getenv('ASG_USE_TERMINATION_POLICY', False)),
+    'ASG_OVERSCALE_INSTANCES': int(os.getenv('ASG_OVERSCALE_INSTANCES', 0)),
     'INSTANCE_WAIT_FOR_STOPPING': str_to_bool(os.getenv('INSTANCE_WAIT_FOR_STOPPING', False)),
     'CLUSTER_HEALTH_WAIT': int(os.getenv('CLUSTER_HEALTH_WAIT', 90)),
     'CLUSTER_HEALTH_RETRY': int(os.getenv('CLUSTER_HEALTH_RETRY', 1)),


### PR DESCRIPTION
When cluster-autoscaler is disabled during the upgrade process this causes new pods being scheduled onto the cluster to fail to start running. Adding additional nodes to the cluster prior to the upgrade can help circumvent this issue and then when cluster auto-scaler is turned back on it can remove unneeded nodes.