### PR TITLE
updating deprecated command

### DIFF
--- a/eksrollup/lib/k8s.py
+++ b/eksrollup/lib/k8s.py
@@ -169,7 +169,7 @@ def drain_node(node_name):
     kubectl_args = [
         'kubectl', 'drain', node_name,
         '--ignore-daemonsets',
-        '--delete-local-data'
+        '--delete-emptydir-data'
     ]
     kubectl_args += app_config['EXTRA_DRAIN_ARGS']
 


### PR DESCRIPTION
When running this script I get the following warning:
```
Flag --delete-local-data has been deprecated, This option is deprecated and will be deleted. Use --delete-emptydir-data.
```

Updating the command now before its completely removed