### PR TITLE
[APPSEC-480] Add dependabot configuration file to .github directory

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    rebase-strategy: "disabled"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
**What is this PR about?**
• For general version updates of 3rd-party libraries irrespective of security vulnerabilities
• Base configuration for dependabot version update

**Why are we doing this?**
• To give you the option of automating general version updates of 3rd-party libraries through Dependabot, by approving this PR. However, you can choose to ignore this if you don't want this automation.

**How does it help you?**
• Reduces your effort and time for version updates by eliminating the need to manually configure this

**Note:** You can modify the base configuration to suit your needs, please see the [documentation and samples](https://github.com/hellofresh/security-examples/tree/master/.github/dependabot/dependency-update)

Please reach out to APS squad at #security OR #security-ghas-help OR @security-aps on Slack for any question